### PR TITLE
docs: remove redundant labels trigger from design

### DIFF
--- a/MVP_DESIGN.md
+++ b/MVP_DESIGN.md
@@ -20,11 +20,12 @@ Conductor uses **GitHub Issue Labels** to maintain state across ephemeral GitHub
 
 1. **Persona Assignment**: The label `persona: <name>` (e.g., `persona: coder`) determines which persona is active.
 2. **Branch Tracking**: The label `branch: <name>` (e.g., `branch: feat/json-parser`) tells the framework which Git branch to checkout before executing the persona logic.
-3. **Execution**: The GitHub Action triggers **only** when a new comment is added. It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
+3. **Execution**: The GitHub Action triggers on **comments**, **issue creation**, and **project status changes** (via repository dispatch). It does **not** trigger on label changes, as this would cause redundant and potentially harmful recursive execution during persona handoffs.
 4. **Handoff**: A persona hands off by:
    - Setting the `persona:` label for the next agent.
    - Setting (or maintaining) the `branch:` label.
    - Posting a comment with instructions.
+   The workflow triggers only after the comment is posted, ensuring the next agent has the necessary context.
 
 ## Workflow: Feature-to-PR
 

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -144,5 +144,6 @@ The current local `gh` token and repo secret were refreshed with:
 ## Notes
 
 - `repository_dispatch` is the only GitHub-native workflow trigger in this chain.
+- `labeled` events are explicitly excluded from the workflow configuration to prevent redundant or recursive runs when agents update state.
 - The project itself is for centralized visibility and control.
 - The webhook bridge is what converts project activity into a workflow event.


### PR DESCRIPTION
Updates MVP_DESIGN.md and PROJECTS_V2_INTEGRATION.md to reflect that label changes do not trigger the workflow, avoiding redundant and harmful recursive runs. This matches the current implementation in conductor.yml.