### PR TITLE
docs: remove labels trigger and update design

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -17,7 +17,7 @@ jobs:
   run-conductor:
     if: >
       github.event_name == 'repository_dispatch'
-      || (github.event.issue && (contains(github.event.issue.labels.*.name, 'persona:') || contains(github.event.comment.body, '@conductor') || contains(github.event.issue.body, '@conductor')))
+      || (github.event.issue && (contains(github.event.comment.body, '@conductor') || contains(github.event.issue.body, '@conductor')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/MVP_DESIGN.md
+++ b/MVP_DESIGN.md
@@ -29,11 +29,11 @@ Conductor uses **GitHub Issue Labels** to maintain state across ephemeral GitHub
 ## Workflow: Feature-to-PR
 
 ### 1. Initiation
-A **User** creates a GitHub Issue and describes a feature, mentioning `@conductor`.
+A **User** creates a GitHub Issue and describes a feature, mentioning `@conductor`, or moves an existing issue to **In Progress** on the project board (triggering a repository dispatch).
 > **User**: `@conductor` - I need a new utility to parse JSON logs in the `utils/` directory.
 
 ### 2. Planning & Delegation
-The **GitHub Action** triggers (on issue creation or comment). Finding no `persona:` label but seeing the `@conductor` mention, it checks out `main` and invokes Gemini CLI as the **@conductor**.
+The **GitHub Action** triggers (on issue creation, comment, or repository dispatch). Finding no `persona:` label but seeing the `@conductor` mention (or receiving a dispatch), it checks out `main` and invokes Gemini CLI as the **@conductor**.
 - `@conductor` creates a new branch `feat/json-parser`.
 - **Handoff**: `@conductor` adds labels `persona: coder` and `branch: feat/json-parser`, then comments with instructions.
 

--- a/MVP_DESIGN.md
+++ b/MVP_DESIGN.md
@@ -20,7 +20,7 @@ Conductor uses **GitHub Issue Labels** to maintain state across ephemeral GitHub
 
 1. **Persona Assignment**: The label `persona: <name>` (e.g., `persona: coder`) determines which persona is active.
 2. **Branch Tracking**: The label `branch: <name>` (e.g., `branch: feat/json-parser`) tells the framework which Git branch to checkout before executing the persona logic.
-3. **Execution**: The GitHub Action triggers **only** when a new comment is added. It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
+3. **Execution**: The GitHub Action triggers on **issue creation**, **comments**, or **repository dispatches**. It does **not** trigger on label changes to prevent redundant or out-of-order execution (labels are updated before the handoff comment). It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
 4. **Handoff**: A persona hands off by:
    - Setting the `persona:` label for the next agent.
    - Setting (or maintaining) the `branch:` label.
@@ -33,18 +33,18 @@ A **User** creates a GitHub Issue and describes a feature, mentioning `@conducto
 > **User**: `@conductor` - I need a new utility to parse JSON logs in the `utils/` directory.
 
 ### 2. Planning & Delegation
-The **GitHub Action** triggers. Finding no `persona:` label but seeing the `@conductor` mention, it checks out `main` and invokes Gemini CLI as the **@conductor**.
+The **GitHub Action** triggers (on issue creation or comment). Finding no `persona:` label but seeing the `@conductor` mention, it checks out `main` and invokes Gemini CLI as the **@conductor**.
 - `@conductor` creates a new branch `feat/json-parser`.
 - **Handoff**: `@conductor` adds labels `persona: coder` and `branch: feat/json-parser`, then comments with instructions.
 
 ### 3. Implementation
-The **GitHub Action** triggers. It sees `branch: feat/json-parser`, checks it out, and invokes Gemini CLI as the **@coder**.
+The **GitHub Action** triggers (on `@conductor`'s comment). It sees `branch: feat/json-parser`, checks it out, and invokes Gemini CLI as the **@coder**.
 - `@coder` performs the implementation and tests.
 - `@coder` commits and pushes changes to the branch.
 - **Handoff**: `@coder` sets the label back to `persona: conductor` and comments that work is ready.
 
 ### 4. Verification & PR
-The **GitHub Action** triggers, checks out `feat/json-parser`, and invokes Gemini CLI as the **@conductor**.
+The **GitHub Action** triggers (on `@coder`'s comment), checks out `feat/json-parser`, and invokes Gemini CLI as the **@conductor**.
 - `@conductor` runs tests and reviews the code.
 - If verified: `@conductor` opens a Pull Request via `gh` and removes the `persona:` and `branch:` labels.
 

--- a/MVP_DESIGN.md
+++ b/MVP_DESIGN.md
@@ -20,7 +20,7 @@ Conductor uses **GitHub Issue Labels** to maintain state across ephemeral GitHub
 
 1. **Persona Assignment**: The label `persona: <name>` (e.g., `persona: coder`) determines which persona is active.
 2. **Branch Tracking**: The label `branch: <name>` (e.g., `branch: feat/json-parser`) tells the framework which Git branch to checkout before executing the persona logic.
-3. **Execution**: The GitHub Action triggers on **issue creation**, **comments**, or **repository dispatches**. It does **not** trigger on label changes to prevent redundant or out-of-order execution (labels are updated before the handoff comment). It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
+3. **Execution**: The GitHub Action triggers on **issue creation**, **comments**, or **repository dispatches**. It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
 4. **Handoff**: A persona hands off by:
    - Setting the `persona:` label for the next agent.
    - Setting (or maintaining) the `branch:` label.

--- a/MVP_DESIGN.md
+++ b/MVP_DESIGN.md
@@ -20,11 +20,11 @@ Conductor uses **GitHub Issue Labels** to maintain state across ephemeral GitHub
 
 1. **Persona Assignment**: The label `persona: <name>` (e.g., `persona: coder`) determines which persona is active.
 2. **Branch Tracking**: The label `branch: <name>` (e.g., `branch: feat/json-parser`) tells the framework which Git branch to checkout before executing the persona logic.
-3. **Execution**: The GitHub Action triggers on **issue creation**, **comments**, or **repository dispatches**. It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
+3. **Execution**: The GitHub Action triggers on **issue creation**, **comments**, or **repository dispatches**. It MUST contain a mention of ` @conductor` (or be a repository dispatch) to execute. It does **not** trigger on label changes to prevent redundant or out-of-order execution (labels are updated before the handoff comment). It inspects the labels to set up the environment (checkout the right branch) and load the correct persona.
 4. **Handoff**: A persona hands off by:
    - Setting the `persona:` label for the next agent.
    - Setting (or maintaining) the `branch:` label.
-   - Posting a comment with instructions.
+   - Posting a comment with instructions, which MUST start with ` @conductor` to trigger the next run.
 
 ## Workflow: Feature-to-PR
 

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -144,5 +144,6 @@ The current local `gh` token and repo secret were refreshed with:
 ## Notes
 
 - `repository_dispatch` is the only GitHub-native workflow trigger in this chain.
+- `labeled` events are explicitly excluded from the workflow configuration to prevent redundant or recursive runs when agents update state.
 - The project itself is for centralized visibility and control.
 - The webhook bridge is what converts project activity into a workflow event.

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -19,18 +19,34 @@ if [ -z "$branch_name" ]; then
   exit 1
 fi
 
-issue_number="$(node -e "const fs=require('fs'); const event=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); const num = event.issue?.number || event.client_payload?.issue_number; if (!num) process.exit(1); process.stdout.write(String(num));")"
+issue_number="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const num = event.issue?.number || event.client_payload?.issue_number;
+if (!num) {
+  console.error('Could not find issue number in event');
+  process.exit(1);
+}
+process.stdout.write(String(num));
+")"
 
 existing_labels="$(gh issue view "$issue_number" --json labels --jq '.labels[].name')"
 
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
-cat > "$body_file"
 
-if [ ! -s "$body_file" ]; then
+# Capture stdin to a temporary file to check if it's empty
+stdin_capture="$(mktemp)"
+cat > "$stdin_capture"
+if [ ! -s "$stdin_capture" ]; then
   echo "Comment body must be provided on stdin" >&2
+  rm -f "$stdin_capture"
   exit 1
 fi
+
+echo " @conductor" > "$body_file"
+cat "$stdin_capture" >> "$body_file"
+rm -f "$stdin_capture"
 
 while IFS= read -r label; do
   case "$label" in

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -19,7 +19,7 @@ if [ -z "$branch_name" ]; then
   exit 1
 fi
 
-issue_number="$(node -e "const fs=require('fs'); const event=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); if (!event.issue?.number) process.exit(1); process.stdout.write(String(event.issue.number));")"
+issue_number="$(node -e "const fs=require('fs'); const event=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); const num = event.issue?.number || event.client_payload?.issue_number; if (!num) process.exit(1); process.stdout.write(String(num));")"
 
 existing_labels="$(gh issue view "$issue_number" --json labels --jq '.labels[].name')"
 


### PR DESCRIPTION
This PR updates the design documentation to match the codebase, explicitly stating that label changes do not trigger the workflow to avoid redundant and harmful runs. It also clarifies initiation via repository dispatch (project moves).