### PR TITLE
[codex] fix handoff trigger and label verification

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -17,7 +17,7 @@ jobs:
   run-conductor:
     if: >
       github.event_name == 'repository_dispatch'
-      || (github.event.issue && (contains(github.event.issue.labels.*.name, 'persona:') || contains(github.event.comment.body, '@conductor') || contains(github.event.issue.body, '@conductor')))
+      || (github.event.issue && (contains(join(github.event.issue.labels.*.name, '||'), 'persona: ') || contains(github.event.comment.body, '@conductor') || contains(github.event.issue.body, '@conductor')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -21,7 +21,11 @@ fi
 
 issue_number="$(node -e "const fs=require('fs'); const event=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); if (!event.issue?.number) process.exit(1); process.stdout.write(String(event.issue.number));")"
 
-existing_labels="$(gh issue view "$issue_number" --json labels --jq '.labels[].name')"
+current_labels() {
+  gh issue view "$issue_number" --json labels --jq '.labels[].name'
+}
+
+existing_labels="$(current_labels)"
 
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
@@ -46,5 +50,20 @@ done <<< "$existing_labels"
 gh issue edit "$issue_number" \
   --add-label "persona: $target" \
   --add-label "branch: $branch_name"
+
+verified=0
+for _ in 1 2 3 4 5; do
+  labels_after="$(current_labels)"
+  if grep -Fqx "persona: $target" <<< "$labels_after" && grep -Fqx "branch: $branch_name" <<< "$labels_after"; then
+    verified=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "$verified" -ne 1 ]; then
+  echo "Failed to verify handoff labels on issue $issue_number before posting comment" >&2
+  exit 1
+fi
 
 gh issue comment "$issue_number" --body-file "$body_file"


### PR DESCRIPTION
## What changed
- fixed the workflow gate so persona-driven handoffs match labels like persona: coder and persona: conductor
- made scripts/handoff.sh read back the issue labels after gh issue edit and refuse to post the handoff comment until the target persona and branch labels are visible

## Why
Issue #45 exposed two separate problems:
- the workflow condition used contains(github.event.issue.labels.*.name, 'persona:'), which only matches an exact label named persona: and does not match persona: coder or persona: conductor
- the handoff script assumed gh issue edit was fully observable immediately and posted the comment without confirming the new labels were visible

That combination allowed issue-comment runs to be skipped even when the issue had been handed off.

## Impact
- persona handoffs now trigger from the actual active persona labels instead of only working accidentally when @conductor appears in the issue body or comment
- handoff comments are only posted after the issue shows the expected target labels

## Validation
- bash -n scripts/handoff.sh
- local negative harness confirmed handoff.sh exits before commenting if the expected labels never appear
- branch pushed successfully to GitHub
