### PR TITLE
[codex] add stalled-item recovery watchdog

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -1,5 +1,7 @@
 name: Conductor
 
+run-name: Conductor Issue #${{ github.event.issue.number || github.event.client_payload.issue_number || 'unknown' }}
+
 on:
   repository_dispatch:
     types: [project_in_progress]
@@ -13,6 +15,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: conductor-${{ github.event.issue.number || github.event.client_payload.issue_number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   run-conductor:
     if: >
@@ -20,6 +26,34 @@ jobs:
       || (github.event.issue && (contains(join(github.event.issue.labels.*.name, '||'), 'persona: ') || contains(github.event.comment.body, '@conductor') || contains(github.event.issue.body, '@conductor')))
     runs-on: ubuntu-latest
     steps:
+      - name: Determine Issue Number
+        id: metadata
+        run: |
+          ISSUE_NUMBER=$(jq -r '.issue.number // .client_payload.issue_number // empty' "$GITHUB_EVENT_PATH")
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          echo "Issue: $ISSUE_NUMBER"
+
+      - name: Ensure Workflow Running Label Exists
+        env:
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.metadata.outputs.issue_number }}
+        run: |
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh label create "workflow: running" \
+              --color "0e8a16" \
+              --description "Managed by conductor while a workflow run is active" \
+              >/dev/null 2>&1 || true
+          fi
+
+      - name: Mark Workflow Running
+        env:
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.metadata.outputs.issue_number }}
+        run: |
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" --add-label "workflow: running"
+          fi
+
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
@@ -74,3 +108,13 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: npm start
+
+      - name: Clear Workflow Running Label
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.metadata.outputs.issue_number }}
+        run: |
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" --remove-label "workflow: running" || true
+          fi

--- a/.github/workflows/recover-stalled.yml
+++ b/.github/workflows/recover-stalled.yml
@@ -1,0 +1,39 @@
+name: Recover Stalled Items
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  recover-stalled-items:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CONDUCTOR_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Recover Stalled Items
+        env:
+          CONDUCTOR_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+        run: npm run recover:stalled-items

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Project moves do not trigger GitHub Actions directly. Conductor uses an org-proj
 2. The bridge sends `repository_dispatch` with `event_type=project_in_progress`.
 3. The workflow starts and activates `persona: conductor` on the target issue.
 
+To keep stalled work from getting stranded, Conductor also runs a 5-minute recovery watchdog:
+
+1. Active runs add a workflow-owned `workflow: running` label to the issue they are handling.
+2. `Recover Stalled Items` scans the project for cards still in `In Progress` but missing that label.
+3. Any stalled item is re-dispatched to Conductor with an explicit recovery prompt so it can resume or declare completion.
+
 The bridge in this repository is deployed as a Firebase HTTPS function.
 
 See [PROJECTS_V2_INTEGRATION.md](PROJECTS_V2_INTEGRATION.md) for the exact dispatch contract and setup details.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "firebase:deploy": "npx --yes firebase-tools deploy --only functions",
     "firebase:serve": "npx --yes firebase-tools emulators:start --only functions",
     "handoff": "bash ./scripts/handoff.sh",
+    "recover:stalled-items": "node dist/recover.js",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ interface GitHubEvent {
     project_number?: number;
     project_url?: string;
     status?: string;
+    persona?: 'conductor' | 'coder';
+    event_name?: string;
+    action?: string;
+    body?: string;
   };
 }
 
@@ -162,8 +166,8 @@ async function main() {
   const eventName = process.env.GITHUB_EVENT_NAME;
   let issueNumber = event.issue?.number ?? event.client_payload?.issue_number;
   let labels = event.issue?.labels.map(l => l.name) || [];
-  let issueBody = event.issue?.body || '';
-  let commentBody = event.comment?.body || '';
+  let issueBody = event.issue?.body || event.client_payload?.body || '';
+  let commentBody = event.comment?.body || (event.client_payload?.event_name === 'issue_comment' ? event.client_payload?.body || '' : '');
 
   if (!issueNumber) {
     console.error('No issue number found in event');
@@ -177,15 +181,22 @@ async function main() {
   }
 
   if (eventName === 'repository_dispatch' && !labels.some(label => label.startsWith('persona:'))) {
-    console.log(`repository_dispatch received for issue #${issueNumber}. Activating conductor persona.`);
-    activateConductorPersona(issueNumber);
-    labels.push('persona: conductor');
+    const targetPersona = event.client_payload?.persona === 'coder' ? 'coder' : 'conductor';
+    if (targetPersona === 'conductor') {
+      console.log(`repository_dispatch received for issue #${issueNumber}. Activating conductor persona.`);
+      activateConductorPersona(issueNumber);
+    } else {
+      console.log(`repository_dispatch received for issue #${issueNumber}. Continuing coder persona from recovery payload.`);
+    }
+    labels.push(`persona: ${targetPersona}`);
   }
 
   // 1. Determine Persona
   let persona: 'conductor' | 'coder' | null = null;
   
-  if (labels.includes('persona: coder')) {
+  if (event.client_payload?.persona === 'coder' || event.client_payload?.persona === 'conductor') {
+    persona = event.client_payload.persona;
+  } else if (labels.includes('persona: coder')) {
     persona = 'coder';
   } else if (labels.includes('persona: conductor')) {
     persona = 'conductor';

--- a/src/recover.ts
+++ b/src/recover.ts
@@ -1,0 +1,199 @@
+import { buildRecoveryPrompt, selectRecoveryCandidates, type ProjectIssueItem } from './utils/recovery';
+
+const TARGET_REPO = 'LLM-Orchestration/conductor';
+const PROJECT_OWNER = 'LLM-Orchestration';
+const PROJECT_NUMBER = 1;
+
+interface ProjectItemsPage {
+  organization?: {
+    projectV2?: {
+      items: ProjectItemsConnection;
+    };
+  };
+}
+
+interface ProjectItemsConnection {
+  nodes: Array<{
+    statusField?: { name?: string | null } | null;
+    content?: {
+      number?: number;
+      title?: string;
+      url?: string;
+      body?: string;
+      labels?: { nodes?: Array<{ name?: string | null }> | null } | null;
+      repository?: {
+        nameWithOwner?: string | null;
+      } | null;
+    } | null;
+  }>;
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor?: string | null;
+  };
+}
+
+function requireToken(): string {
+  const token = process.env.CONDUCTOR_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('CONDUCTOR_TOKEN, GH_TOKEN, or GITHUB_TOKEN must be set');
+  }
+  return token;
+}
+
+async function githubGraphql<T>(query: string, variables: Record<string, unknown>, token: string): Promise<T> {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'conductor-recovery-watchdog'
+    },
+    body: JSON.stringify({ query, variables })
+  });
+
+  const body = await response.json();
+  if (!response.ok || body.errors) {
+    throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(body.errors || body)}`);
+  }
+
+  return body.data as T;
+}
+
+async function dispatchRecovery(issueNumber: number, persona: 'conductor' | 'coder', body: string, projectNumber: number, projectUrl: string, token: string): Promise<void> {
+  const response = await fetch(`https://api.github.com/repos/${TARGET_REPO}/dispatches`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'conductor-recovery-watchdog'
+    },
+    body: JSON.stringify({
+      event_type: 'project_in_progress',
+      client_payload: {
+        issue_number: issueNumber,
+        project_number: projectNumber,
+        project_url: projectUrl,
+        status: 'In Progress',
+        persona,
+        event_name: 'issue_comment',
+        action: 'created',
+        body
+      }
+    })
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(`GitHub repository_dispatch failed for issue #${issueNumber}: ${response.status} ${responseBody}`);
+  }
+}
+
+async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
+  const query = `query ProjectItems($owner: String!, $number: Int!, $after: String) {
+    organization(login: $owner) {
+      projectV2(number: $number) {
+        items(first: 100, after: $after) {
+          nodes {
+            statusField: fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            content {
+              ... on Issue {
+                number
+                title
+                url
+                body
+                labels(first: 100) {
+                  nodes {
+                    name
+                  }
+                }
+                repository {
+                  nameWithOwner
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }`;
+
+  const items: ProjectIssueItem[] = [];
+  let after: string | null = null;
+
+  do {
+    const data: ProjectItemsPage = await githubGraphql<ProjectItemsPage>(query, { owner: PROJECT_OWNER, number: PROJECT_NUMBER, after }, token);
+    const page: ProjectItemsConnection | undefined = data.organization?.projectV2?.items;
+    if (!page) {
+      throw new Error(`Could not load project ${PROJECT_OWNER}/${PROJECT_NUMBER}`);
+    }
+
+    for (const node of page.nodes) {
+      const content = node.content;
+      if (!content?.number || content.repository?.nameWithOwner !== TARGET_REPO) {
+        continue;
+      }
+
+      const labels = Array.isArray(content.labels?.nodes)
+        ? content.labels.nodes.flatMap((label: { name?: string | null }) => (label?.name ? [label.name] : []))
+        : [];
+      const personaLabel = labels.find((label: string) => label === 'persona: conductor' || label === 'persona: coder') || null;
+
+      items.push({
+        repository: content.repository.nameWithOwner,
+        issueNumber: content.number,
+        issueTitle: content.title || `Issue #${content.number}`,
+        issueUrl: content.url || '',
+        issueBody: content.body || '',
+        labels,
+        status: node.statusField?.name || null,
+        persona: personaLabel === 'persona: coder' ? 'coder' : personaLabel === 'persona: conductor' ? 'conductor' : null,
+        projectNumber: PROJECT_NUMBER,
+        projectUrl: `https://github.com/orgs/${PROJECT_OWNER}/projects/${PROJECT_NUMBER}`
+      });
+    }
+
+    after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor || null : null;
+  } while (after);
+
+  return items;
+}
+
+async function main(): Promise<void> {
+  const token = requireToken();
+  const items = await loadProjectItems(token);
+  const candidates = selectRecoveryCandidates(items);
+
+  if (candidates.length === 0) {
+    console.log('No stalled in-progress items found.');
+    return;
+  }
+
+  for (const candidate of candidates) {
+    console.log(`Dispatching recovery for issue #${candidate.issueNumber} as ${candidate.targetPersona}`);
+    await dispatchRecovery(
+      candidate.issueNumber,
+      candidate.targetPersona,
+      buildRecoveryPrompt(candidate),
+      candidate.projectNumber,
+      candidate.projectUrl,
+      token
+    );
+  }
+
+  console.log(`Recovery dispatched for ${candidates.length} item(s).`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/utils/recovery.ts
+++ b/src/utils/recovery.ts
@@ -1,0 +1,55 @@
+export const RUNNING_LABEL = 'workflow: running';
+export const IN_PROGRESS_STATUS = 'In Progress';
+
+export interface ProjectIssueItem {
+  repository: string;
+  issueNumber: number;
+  issueTitle: string;
+  issueUrl: string;
+  issueBody: string;
+  labels: string[];
+  status: string | null;
+  persona: 'conductor' | 'coder' | null;
+  projectNumber: number;
+  projectUrl: string;
+}
+
+export interface RecoveryCandidate extends ProjectIssueItem {
+  targetPersona: 'conductor' | 'coder';
+}
+
+export function resolveTargetPersona(item: Pick<ProjectIssueItem, 'persona' | 'labels'>): 'conductor' | 'coder' {
+  if (item.persona === 'conductor' || item.persona === 'coder') {
+    return item.persona;
+  }
+
+  if (item.labels.includes('persona: coder')) {
+    return 'coder';
+  }
+
+  return 'conductor';
+}
+
+export function selectRecoveryCandidates(items: ProjectIssueItem[]): RecoveryCandidate[] {
+  return items
+    .filter((item) => item.status === IN_PROGRESS_STATUS)
+    .filter((item) => !item.labels.includes(RUNNING_LABEL))
+    .map((item) => ({
+      ...item,
+      targetPersona: resolveTargetPersona(item)
+    }));
+}
+
+export function buildRecoveryPrompt(item: RecoveryCandidate): string {
+  return [
+    `Recovery watchdog detected that ${item.repository}#${item.issueNumber} is still in "${IN_PROGRESS_STATUS}" on the AI Orchestration project, but no active workflow-owned \`${RUNNING_LABEL}\` label is present.`,
+    '',
+    'Resume from the current live issue, branch, and project state.',
+    'If the work is already complete, perform the normal completion path now so the item no longer appears stalled.',
+    'If the work is not complete, continue or hand off explicitly. Do not exit without leaving the issue in a recoverable state.',
+    '',
+    `Issue: ${item.issueTitle}`,
+    `Project: ${item.projectUrl}`,
+    `Recovered Persona: ${item.targetPersona}`
+  ].join('\n');
+}

--- a/tests/utils/recovery.test.ts
+++ b/tests/utils/recovery.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  IN_PROGRESS_STATUS,
+  RUNNING_LABEL,
+  buildRecoveryPrompt,
+  resolveTargetPersona,
+  selectRecoveryCandidates,
+  type ProjectIssueItem
+} from '../../src/utils/recovery';
+
+function makeItem(overrides: Partial<ProjectIssueItem> = {}): ProjectIssueItem {
+  return {
+    repository: 'LLM-Orchestration/conductor',
+    issueNumber: 45,
+    issueTitle: 'support cross-repository work',
+    issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/45',
+    issueBody: 'body',
+    labels: [],
+    status: IN_PROGRESS_STATUS,
+    persona: 'conductor',
+    projectNumber: 1,
+    projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+    ...overrides
+  };
+}
+
+describe('recovery helpers', () => {
+  it('prefers an explicit persona when present', () => {
+    expect(resolveTargetPersona(makeItem({ persona: 'coder', labels: ['persona: conductor'] }))).toBe('coder');
+  });
+
+  it('falls back to labels and then conductor', () => {
+    expect(resolveTargetPersona(makeItem({ persona: null, labels: ['persona: coder'] }))).toBe('coder');
+    expect(resolveTargetPersona(makeItem({ persona: null, labels: [] }))).toBe('conductor');
+  });
+
+  it('selects only in-progress items missing the running label', () => {
+    const candidates = selectRecoveryCandidates([
+      makeItem(),
+      makeItem({ issueNumber: 46, labels: [RUNNING_LABEL] }),
+      makeItem({ issueNumber: 47, status: 'Todo' })
+    ]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.issueNumber).toBe(45);
+  });
+
+  it('builds a recovery prompt with the critical recovery instructions', () => {
+    const prompt = buildRecoveryPrompt({
+      ...makeItem(),
+      targetPersona: 'coder'
+    });
+
+    expect(prompt).toContain(RUNNING_LABEL);
+    expect(prompt).toContain('Recovered Persona: coder');
+    expect(prompt).toContain('support cross-repository work');
+  });
+});


### PR DESCRIPTION
## What changed

This adds a scheduled recovery path for project items that are still `In Progress` but no longer have an active conductor workflow keeping them moving.

- add a new `Recover Stalled Items` workflow that runs every 5 minutes and can also be started manually
- add a workflow-owned `workflow: running` label that the main conductor workflow sets at startup and clears on exit
- add a typed recovery runner that scans the org project, finds stalled conductor-repo items, and re-dispatches conductor with an explicit recovery prompt
- teach `src/index.ts` to honor recovery payload persona/body context on `repository_dispatch`
- document the watchdog behavior in the README

## Why

The current system can stall when an issue remains `In Progress` on the project but no active workflow is still attached to it. In that state nothing re-triggers conductor, so the task sits indefinitely until a human notices it.

The watchdog closes that gap without adding a second orchestration path. It reuses the existing `repository_dispatch` entrypoint and gives conductor a recovery-specific prompt telling it to either resume work or complete the task cleanly.

## Impact

- stalled in-progress items are retried automatically within 5 minutes
- only `LLM-Orchestration/conductor` issues are considered, matching the current `main` workflow architecture
- duplicate concurrent runs for the same issue are constrained by workflow `concurrency`

## Validation

- `npm run build`
- `npm test`
- YAML parse check for `.github/workflows/conductor.yml`
- YAML parse check for `.github/workflows/recover-stalled.yml`
