### PR TITLE
[codex] add orphaned in-progress recovery watchdog

### DIFF
--- a/.github/workflows/recover-orphaned-items.yml
+++ b/.github/workflows/recover-orphaned-items.yml
@@ -1,0 +1,35 @@
+name: Recover Orphaned In Progress Items
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  recover-orphaned-items:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Scan Project and Re-dispatch Orphans
+        env:
+          CONDUCTOR_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+        run: npm run recover:orphans

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -170,6 +170,12 @@ The Conductor is triggered by Project V2 activity:
 2. The webhook bridge detects the `Persona` field change and dispatches a new `repository_dispatch`.
 3. The next agent (e.g., `coder`) starts its work.
 
+### 3. Recovering Orphaned Items
+1. A scheduled workflow in `LLM-Orchestration/conductor` runs every 5 minutes.
+2. It scans Project `#1` for items still in `In Progress`.
+3. If an item has no non-completed Conductor workflow run targeting that repository/issue, it re-dispatches `project_in_progress` for that item.
+4. This allows stalled items to be reactivated without manual project churn.
+
 ### Audit Trail
 - Comments on issues are used for the audit trail and human-in-the-loop feedback, but they do not currently trigger the workflow directly. The live webhook is only subscribed to `projects_v2_item`.
 

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -174,7 +174,8 @@ The Conductor is triggered by Project V2 activity:
 1. A scheduled workflow in `LLM-Orchestration/conductor` runs every 5 minutes.
 2. It scans Project `#1` for items still in `In Progress`.
 3. If an item has no non-completed Conductor workflow run targeting that repository/issue, it re-dispatches `project_in_progress` for that item.
-4. This allows stalled items to be reactivated without manual project churn.
+4. Recovery attempts are capped so the watchdog will not endlessly re-trigger the same stalled item.
+5. The same scanner can be exercised safely with `npm run recover:orphans:dry-run`, which prints the intended re-dispatches without sending them.
 
 ### Audit Trail
 - Comments on issues are used for the audit trail and human-in-the-loop feedback, but they do not currently trigger the workflow directly. The live webhook is only subscribed to `projects_v2_item`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Current Firebase bridge project:
 - `llm-orch-conductor-bridge`
 
 The repository also includes a scheduled recovery workflow that scans the shared project every 5 minutes for `In Progress` items with no non-completed Conductor run and re-dispatches them.
+You can exercise the same scanner without re-triggering work via `npm run recover:orphans:dry-run`.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Current Firebase bridge project:
 
 - `llm-orch-conductor-bridge`
 
+The repository also includes a scheduled recovery workflow that scans the shared project every 5 minutes for `In Progress` items with no non-completed Conductor run and re-dispatches them.
+
 ## Licensing
 
 This project is licensed under the GPLv3 License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "firebase:deploy": "npx --yes firebase-tools deploy --only functions",
     "firebase:serve": "npx --yes firebase-tools emulators:start --only functions",
     "recover:orphans": "node dist/recover-orphans.js",
+    "recover:orphans:dry-run": "node dist/recover-orphans.js --dry-run",
     "handoff": "bash ./scripts/handoff.sh",
     "hook:pre-commit": "bash ./scripts/pre-commit.sh",
     "hook:pre-push": "bash ./scripts/pre-push.sh",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "npm run build",
     "firebase:deploy": "npx --yes firebase-tools deploy --only functions",
     "firebase:serve": "npx --yes firebase-tools emulators:start --only functions",
+    "recover:orphans": "node dist/recover-orphans.js",
     "handoff": "bash ./scripts/handoff.sh",
     "hook:pre-commit": "bash ./scripts/pre-commit.sh",
     "hook:pre-push": "bash ./scripts/pre-push.sh",

--- a/src/recover-orphans.ts
+++ b/src/recover-orphans.ts
@@ -1,0 +1,233 @@
+import dotenv from 'dotenv';
+
+import {
+  ConductorWorkflowRun,
+  findOrphanedItems,
+  normalizePersona,
+  ProjectIssueItem
+} from './utils/recover';
+
+const ORG_LOGIN = process.env.CONDUCTOR_PROJECT_OWNER || 'LLM-Orchestration';
+const PROJECT_NUMBER = Number(process.env.CONDUCTOR_PROJECT_NUMBER || '1');
+const TARGET_STATUS = 'In Progress';
+const TARGET_REPO = process.env.CONDUCTOR_REPO || 'LLM-Orchestration/conductor';
+const WORKFLOW_FILE = process.env.CONDUCTOR_WORKFLOW_FILE || 'conductor.yml';
+
+interface GraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+interface ProjectItemsQuery {
+  organization?: {
+    projectV2?: {
+      url: string;
+      items: {
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string | null;
+        };
+        nodes: Array<{
+          status?: { name?: string | null } | null;
+          persona?: { name?: string | null } | null;
+          content?: {
+            number?: number | null;
+            url?: string | null;
+            repository?: { nameWithOwner?: string | null } | null;
+          } | null;
+        }>;
+      };
+    } | null;
+  } | null;
+}
+
+interface WorkflowRunsResponse {
+  workflow_runs?: Array<ConductorWorkflowRun>;
+}
+
+function getToken(): string {
+  const token = process.env.CONDUCTOR_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('CONDUCTOR_TOKEN, GH_TOKEN, or GITHUB_TOKEN must be set');
+  }
+  return token;
+}
+
+async function githubGraphql<T>(query: string, variables: Record<string, unknown>, token: string): Promise<T> {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'conductor-orphan-recovery'
+    },
+    body: JSON.stringify({ query, variables })
+  });
+
+  const body = (await response.json()) as GraphqlResponse<T>;
+  if (!response.ok || body.errors?.length) {
+    throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(body.errors || body)}`);
+  }
+
+  if (!body.data) {
+    throw new Error('GitHub GraphQL request returned no data');
+  }
+
+  return body.data;
+}
+
+async function githubRest<T>(path: string, token: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'conductor-orphan-recovery',
+      ...(init?.headers || {})
+    }
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub REST request failed for ${path}: ${response.status} ${text}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
+  const query = `
+    query ProjectItems($org: String!, $number: Int!, $after: String) {
+      organization(login: $org) {
+        projectV2(number: $number) {
+          url
+          items(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              status: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+              persona: fieldValueByName(name: "Persona") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+              content {
+                ... on Issue {
+                  number
+                  url
+                  repository {
+                    nameWithOwner
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const items: ProjectIssueItem[] = [];
+  let after: string | null = null;
+
+  while (true) {
+    const data: ProjectItemsQuery = await githubGraphql<ProjectItemsQuery>(
+      query,
+      { org: ORG_LOGIN, number: PROJECT_NUMBER, after },
+      token
+    );
+    const project: NonNullable<NonNullable<ProjectItemsQuery['organization']>['projectV2']> | null =
+      data.organization?.projectV2 ?? null;
+    if (!project) {
+      throw new Error(`Project ${ORG_LOGIN}#${PROJECT_NUMBER} was not found`);
+    }
+
+    for (const node of project.items.nodes) {
+      const repository = node.content?.repository?.nameWithOwner;
+      const issueNumber = node.content?.number;
+      const issueUrl = node.content?.url;
+      const status = node.status?.name;
+      if (!repository || !issueNumber || !issueUrl || !status) continue;
+
+      items.push({
+        repository,
+        issueNumber,
+        issueUrl,
+        projectNumber: PROJECT_NUMBER,
+        projectUrl: project.url,
+        status,
+        persona: node.persona?.name === 'coder' || node.persona?.name === 'conductor' ? node.persona.name : null
+      });
+    }
+
+    if (!project.items.pageInfo.hasNextPage) {
+      break;
+    }
+    after = project.items.pageInfo.endCursor;
+  }
+
+  return items;
+}
+
+async function loadWorkflowRuns(token: string): Promise<ConductorWorkflowRun[]> {
+  const data = await githubRest<WorkflowRunsResponse>(
+    `/repos/${TARGET_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=100`,
+    token
+  );
+  return Array.isArray(data.workflow_runs) ? data.workflow_runs : [];
+}
+
+async function dispatchRecovery(item: ProjectIssueItem, token: string): Promise<void> {
+  await githubRest(
+    `/repos/${TARGET_REPO}/dispatches`,
+    token,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        event_type: 'project_in_progress',
+        client_payload: {
+          repository: item.repository,
+          issue_number: item.issueNumber,
+          issue_url: item.issueUrl,
+          project_number: item.projectNumber,
+          project_url: item.projectUrl,
+          status: TARGET_STATUS,
+          persona: normalizePersona(item.persona),
+          event_name: 'schedule',
+          action: 'recover_orphaned_in_progress'
+        }
+      })
+    }
+  );
+}
+
+async function main(): Promise<void> {
+  dotenv.config();
+
+  const token = getToken();
+  const [items, runs] = await Promise.all([
+    loadProjectItems(token),
+    loadWorkflowRuns(token)
+  ]);
+
+  const orphanedItems = findOrphanedItems(items, runs);
+  console.log(`Scanned ${items.length} project items; found ${orphanedItems.length} orphaned in-progress items.`);
+
+  for (const item of orphanedItems) {
+    console.log(`Re-dispatching ${item.repository}#${item.issueNumber} as ${normalizePersona(item.persona)}.`);
+    await dispatchRecovery(item, token);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/recover-orphans.ts
+++ b/src/recover-orphans.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 
 import {
+  countRecoveryAttempts,
   ConductorWorkflowRun,
   findOrphanedItems,
   normalizePersona,
@@ -12,6 +13,12 @@ const PROJECT_NUMBER = Number(process.env.CONDUCTOR_PROJECT_NUMBER || '1');
 const TARGET_STATUS = 'In Progress';
 const TARGET_REPO = process.env.CONDUCTOR_REPO || 'LLM-Orchestration/conductor';
 const WORKFLOW_FILE = process.env.CONDUCTOR_WORKFLOW_FILE || 'conductor.yml';
+const DEFAULT_MAX_RETRIES = Number(process.env.CONDUCTOR_RECOVERY_MAX_RETRIES || '5');
+
+interface RecoverOptions {
+  dryRun: boolean;
+  maxRetries: number;
+}
 
 interface GraphqlResponse<T> {
   data?: T;
@@ -51,6 +58,43 @@ function getToken(): string {
     throw new Error('CONDUCTOR_TOKEN, GH_TOKEN, or GITHUB_TOKEN must be set');
   }
   return token;
+}
+
+function parseArgs(argv: string[]): RecoverOptions {
+  let dryRun = false;
+  let maxRetries = DEFAULT_MAX_RETRIES;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    if (arg === '--max-retries') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--max-retries requires a numeric value');
+      }
+      maxRetries = Number(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--max-retries=')) {
+      maxRetries = Number(arg.split('=')[1]);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error(`--max-retries must be a non-negative integer, got: ${maxRetries}`);
+  }
+
+  return { dryRun, maxRetries };
 }
 
 async function githubGraphql<T>(query: string, variables: Record<string, unknown>, token: string): Promise<T> {
@@ -94,7 +138,12 @@ async function githubRest<T>(path: string, token: string, init?: RequestInit): P
     throw new Error(`GitHub REST request failed for ${path}: ${response.status} ${text}`);
   }
 
-  return (await response.json()) as T;
+  const text = await response.text();
+  if (!text.trim()) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text) as T;
 }
 
 async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
@@ -211,6 +260,7 @@ async function dispatchRecovery(item: ProjectIssueItem, token: string): Promise<
 
 async function main(): Promise<void> {
   dotenv.config();
+  const options = parseArgs(process.argv.slice(2));
 
   const token = getToken();
   const [items, runs] = await Promise.all([
@@ -219,10 +269,31 @@ async function main(): Promise<void> {
   ]);
 
   const orphanedItems = findOrphanedItems(items, runs);
-  console.log(`Scanned ${items.length} project items; found ${orphanedItems.length} orphaned in-progress items.`);
+  console.log(
+    `Scanned ${items.length} project items; found ${orphanedItems.length} orphaned in-progress items ` +
+    `(dryRun=${options.dryRun}, maxRetries=${options.maxRetries}).`
+  );
 
   for (const item of orphanedItems) {
-    console.log(`Re-dispatching ${item.repository}#${item.issueNumber} as ${normalizePersona(item.persona)}.`);
+    const retries = countRecoveryAttempts(item, runs);
+    if (retries >= options.maxRetries) {
+      console.log(
+        `Skipping ${item.repository}#${item.issueNumber}: recovery attempts exhausted ` +
+        `(${retries}/${options.maxRetries}).`
+      );
+      continue;
+    }
+
+    const persona = normalizePersona(item.persona);
+    if (options.dryRun) {
+      console.log(
+        `[dry-run] Would re-dispatch ${item.repository}#${item.issueNumber} as ${persona} ` +
+        `(retry ${retries + 1}/${options.maxRetries}).`
+      );
+      continue;
+    }
+
+    console.log(`Re-dispatching ${item.repository}#${item.issueNumber} as ${persona} (retry ${retries + 1}/${options.maxRetries}).`);
     await dispatchRecovery(item, token);
   }
 }

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -1,0 +1,50 @@
+export interface ProjectIssueItem {
+  repository: string;
+  issueNumber: number;
+  issueUrl: string;
+  projectNumber: number;
+  projectUrl: string;
+  status: string;
+  persona: 'conductor' | 'coder' | null;
+}
+
+export interface ConductorWorkflowRun {
+  status: string;
+  display_title?: string | null;
+}
+
+export interface RunTarget {
+  repository: string;
+  issueNumber: number;
+}
+
+const CONDUCTOR_RUN_TITLE = /^Conductor \[(.+)\] Issue #(\d+)\b/;
+
+export function parseRunTarget(displayTitle?: string | null): RunTarget | null {
+  if (!displayTitle) return null;
+
+  const match = displayTitle.match(CONDUCTOR_RUN_TITLE);
+  if (!match) return null;
+
+  return {
+    repository: match[1],
+    issueNumber: Number(match[2])
+  };
+}
+
+export function normalizePersona(persona?: string | null): 'conductor' | 'coder' {
+  return persona === 'coder' ? 'coder' : 'conductor';
+}
+
+export function hasActiveRun(item: ProjectIssueItem, runs: ConductorWorkflowRun[]): boolean {
+  return runs.some(run => {
+    if (run.status === 'completed') return false;
+
+    const target = parseRunTarget(run.display_title);
+    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
+  });
+}
+
+export function findOrphanedItems(items: ProjectIssueItem[], runs: ConductorWorkflowRun[]): ProjectIssueItem[] {
+  return items.filter(item => item.status === 'In Progress' && !hasActiveRun(item, runs));
+}

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -19,6 +19,7 @@ export interface RunTarget {
 }
 
 const CONDUCTOR_RUN_TITLE = /^Conductor \[(.+)\] Issue #(\d+)\b/;
+const RECOVERY_RUN_SUFFIX = 'Event: schedule (recover_orphaned_in_progress)';
 
 export function parseRunTarget(displayTitle?: string | null): RunTarget | null {
   if (!displayTitle) return null;
@@ -36,6 +37,10 @@ export function normalizePersona(persona?: string | null): 'conductor' | 'coder'
   return persona === 'coder' ? 'coder' : 'conductor';
 }
 
+export function isRecoveryRun(run: ConductorWorkflowRun): boolean {
+  return typeof run.display_title === 'string' && run.display_title.includes(RECOVERY_RUN_SUFFIX);
+}
+
 export function hasActiveRun(item: ProjectIssueItem, runs: ConductorWorkflowRun[]): boolean {
   return runs.some(run => {
     if (run.status === 'completed') return false;
@@ -43,6 +48,15 @@ export function hasActiveRun(item: ProjectIssueItem, runs: ConductorWorkflowRun[
     const target = parseRunTarget(run.display_title);
     return target?.repository === item.repository && target.issueNumber === item.issueNumber;
   });
+}
+
+export function countRecoveryAttempts(item: ProjectIssueItem, runs: ConductorWorkflowRun[]): number {
+  return runs.filter(run => {
+    if (!isRecoveryRun(run)) return false;
+
+    const target = parseRunTarget(run.display_title);
+    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
+  }).length;
 }
 
 export function findOrphanedItems(items: ProjectIssueItem[], runs: ConductorWorkflowRun[]): ProjectIssueItem[] {

--- a/tests/utils/recover.test.ts
+++ b/tests/utils/recover.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  countRecoveryAttempts,
   findOrphanedItems,
   hasActiveRun,
+  isRecoveryRun,
   normalizePersona,
   parseRunTarget,
   ProjectIssueItem
@@ -18,6 +20,18 @@ describe('recover utils', () => {
 
   it('returns null for non-conductor titles', () => {
     expect(parseRunTarget('CI run')).toBeNull();
+  });
+
+  it('detects watchdog recovery-triggered runs from their title', () => {
+    expect(isRecoveryRun({
+      status: 'completed',
+      display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: schedule (recover_orphaned_in_progress)'
+    })).toBe(true);
+
+    expect(isRecoveryRun({
+      status: 'completed',
+      display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: repository_dispatch'
+    })).toBe(false);
   });
 
   it('detects an active run for a matching issue', () => {
@@ -61,6 +75,25 @@ describe('recover utils', () => {
     expect(findOrphanedItems(items, [
       { status: 'in_progress', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #54 - Persona: conductor - Event: repository_dispatch' }
     ])).toEqual([items[0]]);
+  });
+
+  it('counts only retry-mechanism attempts for the matching issue', () => {
+    const item: ProjectIssueItem = {
+      repository: 'LLM-Orchestration/conductor',
+      issueNumber: 53,
+      issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+      projectNumber: 1,
+      projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+      status: 'In Progress',
+      persona: 'coder'
+    };
+
+    expect(countRecoveryAttempts(item, [
+      { status: 'completed', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: schedule (recover_orphaned_in_progress)' },
+      { status: 'queued', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: schedule (recover_orphaned_in_progress)' },
+      { status: 'completed', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: repository_dispatch' },
+      { status: 'completed', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #99 - Persona: coder - Event: schedule (recover_orphaned_in_progress)' }
+    ])).toBe(2);
   });
 
   it('defaults missing or unknown persona to conductor', () => {

--- a/tests/utils/recover.test.ts
+++ b/tests/utils/recover.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findOrphanedItems,
+  hasActiveRun,
+  normalizePersona,
+  parseRunTarget,
+  ProjectIssueItem
+} from '../../src/utils/recover';
+
+describe('recover utils', () => {
+  it('parses conductor run titles into repository and issue number', () => {
+    expect(parseRunTarget('Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: repository_dispatch')).toEqual({
+      repository: 'LLM-Orchestration/conductor',
+      issueNumber: 53
+    });
+  });
+
+  it('returns null for non-conductor titles', () => {
+    expect(parseRunTarget('CI run')).toBeNull();
+  });
+
+  it('detects an active run for a matching issue', () => {
+    const item: ProjectIssueItem = {
+      repository: 'LLM-Orchestration/conductor',
+      issueNumber: 53,
+      issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+      projectNumber: 1,
+      projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+      status: 'In Progress',
+      persona: 'coder'
+    };
+
+    expect(hasActiveRun(item, [
+      { status: 'queued', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #53 - Persona: coder - Event: repository_dispatch' }
+    ])).toBe(true);
+  });
+
+  it('finds only in-progress items without an active conductor run', () => {
+    const items: ProjectIssueItem[] = [
+      {
+        repository: 'LLM-Orchestration/conductor',
+        issueNumber: 53,
+        issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+        projectNumber: 1,
+        projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+        status: 'In Progress',
+        persona: 'coder'
+      },
+      {
+        repository: 'LLM-Orchestration/conductor',
+        issueNumber: 54,
+        issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/54',
+        projectNumber: 1,
+        projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+        status: 'Done',
+        persona: 'conductor'
+      }
+    ];
+
+    expect(findOrphanedItems(items, [
+      { status: 'in_progress', display_title: 'Conductor [LLM-Orchestration/conductor] Issue #54 - Persona: conductor - Event: repository_dispatch' }
+    ])).toEqual([items[0]]);
+  });
+
+  it('defaults missing or unknown persona to conductor', () => {
+    expect(normalizePersona('coder')).toBe('coder');
+    expect(normalizePersona('conductor')).toBe('conductor');
+    expect(normalizePersona(null)).toBe('conductor');
+    expect(normalizePersona('reviewer')).toBe('conductor');
+  });
+});


### PR DESCRIPTION
## What changed

This adds a small scheduled watchdog that scans the shared `AI Orchestration` project every 5 minutes for items still in `In Progress` that do not currently have a non-completed `Conductor` workflow run targeting them.

If such an orphaned item is found, the watchdog re-dispatches the normal `project_in_progress` event back into `LLM-Orchestration/conductor`, using the item's current `Persona` field when present and defaulting to `conductor` otherwise.

## Why

We just hit a real failure mode where an item remained `In Progress` with `persona: coder`, but no follow-up run was active because the handoff trigger path stalled. In that state the system needed a nudge, not manual project churn.

This PR adds that nudge without introducing a second orchestration protocol:
- the existing `repository_dispatch` path is reused
- no special recovery prompt is injected
- queued and in-progress Conductor runs are treated as alive, so the watchdog only re-triggers items with no active work

## Implementation

- add `npm run recover:orphans`
- add `src/recover-orphans.ts` to query project items and current Conductor runs, then re-dispatch orphaned items
- add `src/utils/recover.ts` with the run-matching/orphan-detection helpers
- add `tests/utils/recover.test.ts`
- add scheduled workflow `.github/workflows/recover-orphaned-items.yml`
- document the watchdog in `README.md` and `PROJECTS_V2_INTEGRATION.md`

## Validation

- `npm run validate`
- pre-push hook re-ran `npm run validate`

## Notes

I did not run the recovery scanner live from this branch, because doing so would have re-dispatched real in-progress work.
