### PR TITLE
[codex] trim repository_dispatch payload

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -59,7 +59,7 @@ async function githubGraphql(query, variables, token) {
   return body.data;
 }
 
-async function dispatchProjectActivation(repository, issueNumber, token, eventName = null, action = null, body = null, issueUrl = null, issueNodeId = null, projectNumber = null, projectUrl = null, persona = null) {
+async function dispatchProjectActivation(repository, issueNumber, token, eventName = null, action = null, issueNodeId = null, projectNumber = null, projectUrl = null, persona = null) {
   const response = await fetch(`https://api.github.com/repos/${TARGET_REPO}/dispatches`, {
     method: "POST",
     headers: {
@@ -73,15 +73,12 @@ async function dispatchProjectActivation(repository, issueNumber, token, eventNa
       client_payload: {
         repository: repository,
         issue_number: issueNumber,
-        issue_url: issueUrl,
         issue_node_id: issueNodeId,
         project_number: projectNumber,
         project_url: projectUrl,
-        status: TARGET_STATUS,
         persona: persona,
         event_name: eventName,
-        action: action,
-        body: body
+        action: action
       }
     })
   });
@@ -188,8 +185,6 @@ exports.githubProjectsV2Webhook = onRequest(
               content {
                 ... on Issue {
                   number
-                  body
-                  url
                   id
                   labels(first: 100) {
                     nodes {
@@ -210,12 +205,7 @@ exports.githubProjectsV2Webhook = onRequest(
 
       const item = data?.node;
       const issueNumber = item?.content?.number;
-      const issueBody = item?.content?.body;
-      const issueUrl = item?.content?.url;
       const issueNodeId = item?.content?.id;
-      const issueLabels = Array.isArray(item?.content?.labels?.nodes)
-        ? item.content.labels.nodes.map((label) => label.name)
-        : [];
       const repositoryName = item?.content?.repository?.nameWithOwner;
       const projectNumber = item?.project?.number;
       const projectUrl = item?.project?.url;
@@ -271,7 +261,7 @@ exports.githubProjectsV2Webhook = onRequest(
         return;
       }
 
-      await dispatchProjectActivation(repositoryName, issueNumber, conductorToken.value(), eventName, action, issueBody, issueUrl, issueNodeId, projectNumber, projectUrl, personaName);
+      await dispatchProjectActivation(repositoryName, issueNumber, conductorToken.value(), eventName, action, issueNodeId, projectNumber, projectUrl, personaName);
       logger.info("Dispatched project activation", { deliveryId, repositoryName, issueNumber, statusName, personaName, projectNumber });
       res.status(202).json({ ok: true, repository: repositoryName, issueNumber, status: statusName, persona: personaName, projectNumber });
     } catch (error) {

--- a/src/recover-orphans.ts
+++ b/src/recover-orphans.ts
@@ -10,7 +10,6 @@ import {
 
 const ORG_LOGIN = process.env.CONDUCTOR_PROJECT_OWNER || 'LLM-Orchestration';
 const PROJECT_NUMBER = Number(process.env.CONDUCTOR_PROJECT_NUMBER || '1');
-const TARGET_STATUS = 'In Progress';
 const TARGET_REPO = process.env.CONDUCTOR_REPO || 'LLM-Orchestration/conductor';
 const WORKFLOW_FILE = process.env.CONDUCTOR_WORKFLOW_FILE || 'conductor.yml';
 const DEFAULT_MAX_RETRIES = Number(process.env.CONDUCTOR_RECOVERY_MAX_RETRIES || '5');
@@ -173,7 +172,6 @@ async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
                 ... on Issue {
                   id
                   number
-                  url
                   repository {
                     nameWithOwner
                   }
@@ -204,15 +202,13 @@ async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
     for (const node of project.items.nodes) {
       const repository = node.content?.repository?.nameWithOwner;
       const issueNumber = node.content?.number;
-      const issueUrl = node.content?.url;
       const issueNodeId = node.content?.id;
       const status = node.status?.name;
-      if (!repository || !issueNumber || !issueUrl || !issueNodeId || !status) continue;
+      if (!repository || !issueNumber || !issueNodeId || !status) continue;
 
       items.push({
         repository,
         issueNumber,
-        issueUrl,
         issueNodeId,
         projectNumber: PROJECT_NUMBER,
         projectUrl: project.url,
@@ -249,11 +245,9 @@ async function dispatchRecovery(item: ProjectIssueItem, token: string): Promise<
         client_payload: {
           repository: item.repository,
           issue_number: item.issueNumber,
-          issue_url: item.issueUrl,
           issue_node_id: item.issueNodeId,
           project_number: item.projectNumber,
           project_url: item.projectUrl,
-          status: TARGET_STATUS,
           persona: normalizePersona(item.persona),
           event_name: 'schedule',
           action: 'recover_orphaned_in_progress'

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -13,14 +13,11 @@ export interface GitHubEvent {
   client_payload?: {
     repository?: string;
     issue_number?: number;
-    issue_url?: string;
     issue_node_id?: string;
     project_item_id?: string;
     project_number?: number;
     project_url?: string;
-    status?: string;
     persona?: string;
-    body?: string;
     event_name?: string;
     action?: string;
   };
@@ -29,11 +26,11 @@ export interface GitHubEvent {
 export function extractEventData(event: GitHubEvent, env: NodeJS.ProcessEnv) {
   const repository = event.client_payload?.repository || env.GITHUB_REPOSITORY || '';
   const issueNumber = event.issue?.number ?? event.client_payload?.issue_number;
-  const issueUrl = event.issue?.html_url || event.client_payload?.issue_url || '';
+  const issueUrl = event.issue?.html_url || '';
   const issueNodeId = event.issue?.node_id || event.client_payload?.issue_node_id || '';
   const labels = event.issue?.labels?.map(l => l.name) || [];
-  const issueBody = event.issue?.body || event.client_payload?.body || '';
-  const commentBody = event.comment?.body || event.client_payload?.body || '';
+  const issueBody = event.issue?.body || '';
+  const commentBody = event.comment?.body || '';
   const projectNumber = event.client_payload?.project_number;
   const projectUrl = event.client_payload?.project_url;
   const eventName = event.client_payload?.event_name || env.GITHUB_EVENT_NAME || '';

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -1,7 +1,6 @@
 export interface ProjectIssueItem {
   repository: string;
   issueNumber: number;
-  issueUrl: string;
   issueNodeId: string;
   projectNumber: number;
   projectUrl: string;

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -27,16 +27,14 @@ describe('extractEventData', () => {
       client_payload: {
         repository: 'other/repo',
         issue_number: 456,
-        issue_url: 'https://github.com/other/repo/issues/456',
-        issue_node_id: 'I_456',
-        status: 'In Progress'
+        issue_node_id: 'I_456'
       }
     };
     const env = { GITHUB_REPOSITORY: 'owner/repo' };
     const result = extractEventData(event, env);
     expect(result.repository).toBe('other/repo');
     expect(result.issueNumber).toBe(456);
-    expect(result.issueUrl).toBe('https://github.com/other/repo/issues/456');
+    expect(result.issueUrl).toBe('');
     expect(result.issueNodeId).toBe('I_456');
     expect(result.labels).toEqual([]);
   });
@@ -53,33 +51,18 @@ describe('extractEventData', () => {
     expect(result.issueNumber).toBe(456);
   });
 
-  it('should extract body and commentBody from enriched repository_dispatch', () => {
+  it('should not infer body or commentBody from repository_dispatch payload', () => {
     const event: GitHubEvent = {
       client_payload: {
         repository: 'other/repo',
-        issue_number: 789,
-        body: 'comment from payload'
+        issue_number: 789
       }
     };
     const env = { GITHUB_REPOSITORY: 'owner/repo' };
     const result = extractEventData(event, env);
     expect(result.repository).toBe('other/repo');
     expect(result.issueNumber).toBe(789);
-    expect(result.issueBody).toBe('comment from payload'); // issueBody gets it as fallback
-    expect(result.commentBody).toBe('comment from payload');
-  });
-
-  it('should extract body into both if only body is present', () => {
-    const event: GitHubEvent = {
-      client_payload: {
-        repository: 'other/repo',
-        issue_number: 789,
-        body: 'body from payload'
-      }
-    };
-    const env = { GITHUB_REPOSITORY: 'owner/repo' };
-    const result = extractEventData(event, env);
-    expect(result.issueBody).toBe('body from payload');
-    expect(result.commentBody).toBe('body from payload');
+    expect(result.issueBody).toBe('');
+    expect(result.commentBody).toBe('');
   });
 });

--- a/tests/utils/recover.test.ts
+++ b/tests/utils/recover.test.ts
@@ -38,7 +38,7 @@ describe('recover utils', () => {
     const item: ProjectIssueItem = {
       repository: 'LLM-Orchestration/conductor',
       issueNumber: 53,
-      issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+      issueNodeId: 'I_53',
       projectNumber: 1,
       projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
       status: 'In Progress',
@@ -55,7 +55,7 @@ describe('recover utils', () => {
       {
         repository: 'LLM-Orchestration/conductor',
         issueNumber: 53,
-        issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+        issueNodeId: 'I_53',
         projectNumber: 1,
         projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
         status: 'In Progress',
@@ -64,7 +64,7 @@ describe('recover utils', () => {
       {
         repository: 'LLM-Orchestration/conductor',
         issueNumber: 54,
-        issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/54',
+        issueNodeId: 'I_54',
         projectNumber: 1,
         projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
         status: 'Done',
@@ -81,7 +81,7 @@ describe('recover utils', () => {
     const item: ProjectIssueItem = {
       repository: 'LLM-Orchestration/conductor',
       issueNumber: 53,
-      issueUrl: 'https://github.com/LLM-Orchestration/conductor/issues/53',
+      issueNodeId: 'I_53',
       projectNumber: 1,
       projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
       status: 'In Progress',


### PR DESCRIPTION
## Summary
- trim the `repository_dispatch` payload down to only fields the workflow still consumes
- remove the runtime fallback that treated payload `body` as issue/comment context
- align recovery helpers and tests with the smaller dispatch contract

## Why
The Firebase bridge was sending 11 top-level `client_payload` properties, and GitHub rejects `repository_dispatch` requests with more than 10. The extra `body`, `issue_url`, and `status` fields are no longer needed because dispatch-triggered runs fetch live issue state from GitHub before building persona context.

## Validation
- `npm run build`
- `npm test`
- pre-push `npm run validate`
