### PR TITLE
[codex] quote conductor run name

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -1,6 +1,6 @@
 name: Conductor
 
-run-name: Conductor [${{ github.event.client_payload.repository || github.repository }}] Issue #${{ github.event.client_payload.issue_number || github.event.issue.number }} - Persona: ${{ github.event.client_payload.persona || 'unknown' }} - Event: ${{ github.event.client_payload.event_name || github.event_name }}${{ github.event.client_payload.action && format(' ({0})', github.event.client_payload.action) || '' }}
+run-name: "Conductor [${{ github.event.client_payload.repository || github.repository }}] Issue #${{ github.event.client_payload.issue_number || github.event.issue.number }} - Persona: ${{ github.event.client_payload.persona || 'unknown' }} - Event: ${{ github.event.client_payload.event_name || github.event_name }}${{ github.event.client_payload.action && format(' ({0})', github.event.client_payload.action) || '' }}"
 
 on:
   repository_dispatch:


### PR DESCRIPTION
## Summary
- quote the conductor workflow `run-name`
- preserve the `#<issue>` portion of the title so watchdog parsing sees active runs

## Why
The unquoted `run-name` was being truncated at `#` by YAML parsing, so Conductor runs appeared as `Conductor [repo] Issue` instead of including the issue number. The orphan-recovery watchdog parses run titles to detect active work, so it misclassified active issue runs as orphaned and re-dispatched duplicate coder workflows.

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/conductor.yml"); puts data["run-name"]'`
- `npm run validate`
