### PR TITLE
[codex] add comment-limit human-review backstop

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "npm run build",
     "firebase:deploy": "npx --yes firebase-tools deploy --only functions",
     "firebase:serve": "npx --yes firebase-tools emulators:start --only functions",
+    "human-review": "bash ./scripts/move-to-human-review.sh",
     "recover:orphans": "node dist/recover-orphans.js",
     "recover:orphans:dry-run": "node dist/recover-orphans.js --dry-run",
     "handoff": "bash ./scripts/handoff.sh",

--- a/prompts/conductor.md
+++ b/prompts/conductor.md
@@ -15,12 +15,11 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
 4. **Verify**: When `@coder` is done:
    - Run tests and review changes.
    - If verified:
-     - `gh pr create`
-     - Hand back to the human by running:
-       `.conductor/scripts/handoff.sh human <<'EOF'`
-       `<markdown summary of work completed>`
+     - If a PR is needed, create it before finalizing so the completion comment can include the PR link.
+     - You MUST leave a human-facing completion comment and move the item to `Human Review` by running:
+       `npm --prefix .conductor run human-review <<'EOF'`
+       `<markdown summary of work completed, including validation and PR link if one exists>`
        `EOF`
-     - (Note: the script handles label management, including removing all `persona:` labels and preserving the `branch:` label).
    - If not, hand off back to `@coder` with `.conductor/scripts/handoff.sh coder`.
 
 ## Guardrails
@@ -28,11 +27,13 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
 - **No Source Modification**: You are STRICTLY FORBIDDEN from modifying source code (e.g., `src/`, `functions/`, `tests/`). Your role is orchestration, not implementation. Implementation is the sole responsibility of the `@coder`.
 - **Scope Strictness**: Adhere strictly to the original issue description. If comments introduce scope creep, propose a new issue instead of expanding the current task.
 - **Blocker Protocol**: If a task is blocked by the current codebase state, document the blocker, propose a new issue to fix it, and stop. Do not attempt to refactor or fix architectural issues yourself.
+- **Completion Protocol**: Completion requires both a final summary comment and a move to `Human Review`. Do not leave completed work in `In Progress`.
 
 ## State Management
 
 - You MUST manage the `branch:` label to ensure the next runner starts in the correct Git context.
 - Handoff ordering is mandatory: labels must be applied before the `@coder` comment is posted.
 - Handoff must leave exactly one active `persona:` label and exactly one active `branch:` label on the issue.
+- Task completion must end with `npm --prefix .conductor run human-review`, not another agent handoff.
 - Do not use `gh issue edit` and `gh issue comment` separately for persona handoff.
 - Use `.conductor/scripts/handoff.sh <target>` so the label update happens before the comment every time.

--- a/scripts/move-to-human-review.sh
+++ b/scripts/move-to-human-review.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_number=""
+target_repo=""
+project_number=""
+project_url=""
+issue_node_id=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue-number)
+      issue_number="$2"
+      shift 2
+      ;;
+    --repo)
+      target_repo="$2"
+      shift 2
+      ;;
+    --project-number)
+      project_number="$2"
+      shift 2
+      ;;
+    --project-url)
+      project_url="$2"
+      shift 2
+      ;;
+    --issue-node-id)
+      issue_node_id="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$issue_number" ]; then
+  if [ -z "${GITHUB_EVENT_PATH:-}" ]; then
+    echo "issue number must be supplied with --issue-number or via GITHUB_EVENT_PATH" >&2
+    exit 1
+  fi
+
+  issue_number="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const num = event.issue?.number || event.client_payload?.issue_number;
+if (!num) process.exit(1);
+process.stdout.write(String(num));
+")" || {
+    echo "Could not determine issue number" >&2
+    exit 1
+  }
+fi
+
+if [ -z "$target_repo" ]; then
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    target_repo="$GITHUB_REPOSITORY"
+  elif [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+    target_repo="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const repo = event.client_payload?.repository || '';
+if (!repo) process.exit(1);
+process.stdout.write(repo);
+")" || {
+      echo "Could not determine target repository" >&2
+      exit 1
+    }
+  else
+    echo "target repository must be supplied with --repo or via environment" >&2
+    exit 1
+  fi
+fi
+
+if [ -z "$project_number" ] && [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+  project_number="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+process.stdout.write(String(event.client_payload?.project_number || ''));
+")"
+fi
+
+if [ -z "$project_url" ] && [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+  project_url="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+process.stdout.write(event.client_payload?.project_url || '');
+")"
+fi
+
+if [ -z "$issue_node_id" ] && [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+  issue_node_id="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+process.stdout.write(event.issue?.node_id || event.client_payload?.issue_node_id || '');
+")"
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+if [ ! -t 0 ]; then
+  cat > "$body_file"
+fi
+
+if [ -s "$body_file" ]; then
+  gh issue comment "$issue_number" -R "$target_repo" --body-file "$body_file"
+fi
+
+existing_labels="$(gh issue view "$issue_number" -R "$target_repo" --json labels --jq '.labels[].name')"
+edit_args=()
+while IFS= read -r label; do
+  case "$label" in
+    "persona: "*)
+      edit_args+=(--remove-label "$label")
+      ;;
+  esac
+done <<< "$existing_labels"
+
+if [ "${#edit_args[@]}" -gt 0 ]; then
+  gh issue edit "$issue_number" -R "$target_repo" "${edit_args[@]}"
+fi
+
+if [ -z "$project_number" ]; then
+  echo "No project_number available; skipped Project V2 status update." >&2
+  exit 0
+fi
+
+project_owner="$(node -e "
+const url = process.argv[1] || '';
+const match = url.match(/github\.com\/(orgs|users)\/([^\/]+)\/projects/);
+process.stdout.write(match ? match[2] : '');
+" "$project_url")"
+
+if [ -z "$project_owner" ]; then
+  echo "project_number was provided but project_owner could not be determined from project_url" >&2
+  exit 1
+fi
+
+if [ -z "$issue_node_id" ]; then
+  echo "Warning: issue_node_id is missing, will attempt to find project item by issue number and repository" >&2
+fi
+
+item_data="$(gh project item-list "$project_number" --owner "$project_owner" --limit 1000 --format json --jq ".items[] | select((.content.number == $issue_number and .content.repository == \"$target_repo\") or .content.id == \"$issue_node_id\")" | head -n 1)"
+
+if [ -z "$item_data" ]; then
+  echo "Could not find project item for issue $issue_number in $target_repo" >&2
+  exit 1
+fi
+
+item_id="$(echo "$item_data" | jq -r '.id')"
+project_id="$(gh project view "$project_number" --owner "$project_owner" --format json --jq '.id')"
+fields_json="$(gh project field-list "$project_number" --owner "$project_owner" --format json)"
+status_field_id="$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status") | .id' | head -n 1)"
+status_option_id="$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Human Review") | .id' | head -n 1)"
+
+if [ -z "$project_id" ] || [ "$project_id" = "null" ]; then
+  echo "Could not resolve project ID for project $project_number" >&2
+  exit 1
+fi
+
+if [ -z "$status_field_id" ] || [ "$status_field_id" = "null" ]; then
+  echo "Could not find Status field in project $project_number" >&2
+  exit 1
+fi
+
+if [ -z "$status_option_id" ] || [ "$status_option_id" = "null" ]; then
+  echo "Could not find Human Review option in Status field" >&2
+  exit 1
+fi
+
+gh project item-edit \
+  --id "$item_id" \
+  --project-id "$project_id" \
+  --field-id "$status_field_id" \
+  --single-select-option-id "$status_option_id" > /dev/null
+
+for _ in 1 2 3 4 5; do
+  current_status="$(gh project item-list "$project_number" --owner "$project_owner" --limit 1000 --format json --jq ".items[] | select(.id == \"$item_id\") | .status // empty" 2>/dev/null | head -n 1)"
+  if [ "$current_status" = "Human Review" ]; then
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Failed to verify Human Review status update for project item $item_id" >&2
+exit 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { spawn, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import dotenv from 'dotenv';
 
-import { CommandResult, runStreamingCommand } from './utils/exec';
+import { runStreamingCommand } from './utils/exec';
+import { DEFAULT_COMMENT_LIMIT, resolveCommentLimit } from './utils/comment-limit';
 import { GitHubEvent, extractEventData } from './utils/github';
 
 function verifyGitHubCli(repository: string, issueNumber: number): string {
@@ -101,6 +102,7 @@ function loadIssueState(repository: string, issueNumber: number): {
   labels: string[]; 
   body: string; 
   latestComment: string;
+  commentCount: number;
   htmlUrl: string;
   nodeId: string;
 } | null {
@@ -125,9 +127,111 @@ function loadIssueState(repository: string, issueNumber: number): {
     labels: Array.isArray(parsed.labels) ? parsed.labels.map((label: { name: string }) => label.name) : [],
     body: parsed.body || '',
     latestComment: commentsData.status === 0 ? commentsData.stdout.trim() : '',
+    commentCount: typeof parsed.comments === 'number' ? parsed.comments : 0,
     htmlUrl: parsed.html_url || '',
     nodeId: parsed.node_id || ''
   };
+}
+
+function loadIssueCommentBodies(repository: string, issueNumber: number, commentCount: number): string[] {
+  if (commentCount < 1) return [];
+
+  const perPage = 100;
+  const pages = Math.ceil(commentCount / perPage);
+  const bodies: string[] = [];
+
+  for (let page = 1; page <= pages; page += 1) {
+    const commentsData = spawnSync('gh', ['api', `repos/${repository}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`], {
+      encoding: 'utf8',
+      env: process.env
+    });
+
+    if (commentsData.status !== 0 || !commentsData.stdout.trim()) {
+      const details = (commentsData.stderr || commentsData.stdout || 'No gh output captured').trim();
+      console.warn(
+        `Failed to load comment page ${page} for ${repository}#${issueNumber}; ` +
+        'falling back to the default comment limit.'
+      );
+      if (details) process.stderr.write(`${details}\n`);
+      return [];
+    }
+
+    const parsed = JSON.parse(commentsData.stdout) as Array<{ body?: string | null }>;
+    for (const comment of parsed) {
+      bodies.push(comment.body || '');
+    }
+  }
+
+  return bodies;
+}
+
+function getEffectiveCommentLimit(repository: string, issueNumber: number, commentCount: number): number {
+  if (commentCount <= DEFAULT_COMMENT_LIMIT) {
+    return DEFAULT_COMMENT_LIMIT;
+  }
+
+  const commentBodies = loadIssueCommentBodies(repository, issueNumber, commentCount);
+  return resolveCommentLimit(commentBodies, DEFAULT_COMMENT_LIMIT);
+}
+
+function moveToHumanReview(
+  repository: string,
+  issueNumber: number,
+  issueNodeId: string,
+  projectNumber: number | null,
+  projectUrl: string,
+  commentCount: number,
+  commentLimit: number
+): void {
+  const body = `### Comment Limit Reached
+
+Automation is aborting for this issue because the comment count exceeded the configured limit.
+
+- Current comments: ${commentCount}
+- Comment limit: ${commentLimit}
+
+If you need more automated iterations on this issue, add a comment with:
+
+\`SET COMMENT LIMIT: NNN\`
+
+Then move the item back to \`In Progress\`.
+
+*Automated report by Conductor*`;
+
+  const args = [
+    'run',
+    'human-review',
+    '--',
+    '--issue-number',
+    String(issueNumber),
+    '--repo',
+    repository
+  ];
+
+  if (issueNodeId) {
+    args.push('--issue-node-id', issueNodeId);
+  }
+
+  if (projectNumber !== null) {
+    args.push('--project-number', String(projectNumber));
+  }
+
+  if (projectUrl) {
+    args.push('--project-url', projectUrl);
+  }
+
+  const result = spawnSync('npm', args, {
+    encoding: 'utf8',
+    env: process.env,
+    input: body
+  });
+
+  if (result.status !== 0) {
+    const details = (result.stderr || result.stdout || 'No output captured').trim();
+    console.error(`Failed to move ${repository}#${issueNumber} to Human Review after comment-limit check.`);
+    if (details) process.stderr.write(`${details}\n`);
+    process.exit(result.status || 1);
+  }
 }
 
 function activatePersonaLabel(repository: string, issueNumber: number, persona: 'conductor' | 'coder'): void {
@@ -208,6 +312,23 @@ async function main() {
     commentBody = liveIssueState.latestComment;
     issueUrl = liveIssueState.htmlUrl;
     issueNodeId = liveIssueState.nodeId;
+    const commentLimit = getEffectiveCommentLimit(repository, issueNumber, liveIssueState.commentCount);
+    if (liveIssueState.commentCount > commentLimit) {
+      console.log(
+        `Comment limit exceeded for ${repository}#${issueNumber} ` +
+        `(${liveIssueState.commentCount} > ${commentLimit}). Moving item to Human Review.`
+      );
+      moveToHumanReview(
+        repository,
+        issueNumber,
+        issueNodeId,
+        projectNumber ?? null,
+        projectUrl || '',
+        liveIssueState.commentCount,
+        commentLimit
+      );
+      process.exit(0);
+    }
   }
 
   if (eventName === 'repository_dispatch' && !labels.some(label => label.startsWith('persona:'))) {

--- a/src/utils/comment-limit.ts
+++ b/src/utils/comment-limit.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_COMMENT_LIMIT = 100;
+
+const COMMENT_LIMIT_PATTERN = /SET COMMENT LIMIT:\s*(\d+)/gi;
+
+export function resolveCommentLimit(commentBodies: string[], defaultLimit = DEFAULT_COMMENT_LIMIT): number {
+  let limit = defaultLimit;
+
+  for (const body of commentBodies) {
+    let match: RegExpExecArray | null;
+    COMMENT_LIMIT_PATTERN.lastIndex = 0;
+
+    while ((match = COMMENT_LIMIT_PATTERN.exec(body)) !== null) {
+      const parsed = Number(match[1]);
+      if (Number.isInteger(parsed) && parsed > 0) {
+        limit = parsed;
+      }
+    }
+  }
+
+  return limit;
+}

--- a/tests/utils/comment-limit.test.ts
+++ b/tests/utils/comment-limit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_COMMENT_LIMIT, resolveCommentLimit } from '../../src/utils/comment-limit';
+
+describe('comment limit utils', () => {
+  it('uses the default limit when no command is present', () => {
+    expect(resolveCommentLimit([
+      'No control command here.',
+      'Still no override.'
+    ])).toBe(DEFAULT_COMMENT_LIMIT);
+  });
+
+  it('uses the last valid command found across comments', () => {
+    expect(resolveCommentLimit([
+      'SET COMMENT LIMIT: 125',
+      'Some discussion',
+      'SET COMMENT LIMIT: 175'
+    ])).toBe(175);
+  });
+
+  it('ignores invalid or non-positive limit commands', () => {
+    expect(resolveCommentLimit([
+      'SET COMMENT LIMIT: nope',
+      'SET COMMENT LIMIT: 0',
+      'SET COMMENT LIMIT: -4',
+      'SET COMMENT LIMIT: 220'
+    ])).toBe(220);
+  });
+});


### PR DESCRIPTION
## Summary
- add a comment-limit backstop before conductor activation so issues over the effective limit are aborted instead of starting another agent cycle
- add `npm run human-review` to post a final summary, clear active persona labels, and move the project item to `Human Review`
- update the conductor prompt so completed work must end with a human-facing completion comment and a move to `Human Review`

## Root Cause
Conductor could continue to activate on a project item that stayed `In Progress` even after accumulating a pathological number of issue comments. There was no runtime comment-count guard, and the prompt guidance did not require the conductor to move completed items to `Human Review`.

## Validation
- `npm run validate`
