### PR TITLE
Deploy Observability UI to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,93 @@
+name: Deploy UI to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine base path
+        id: base_path
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "path=/$REPO_NAME/pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "dir=pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "path=/$REPO_NAME" >> $GITHUB_OUTPUT
+            echo "dir=." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Observability UI
+        run: |
+          cd observability-ui
+          npm run build
+        env:
+          NODE_ENV: production
+          PUBLIC_BASE_PATH: ${{ steps.base_path.outputs.path }}
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./observability-ui/build
+          destination_dir: ${{ steps.base_path.outputs.dir }}
+          keep_files: true
+
+      - name: Comment PR with preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repoName = context.repo.repo;
+            const owner = context.repo.owner;
+            const previewUrl = `https://${owner}.github.io/${repoName}/pr${prNumber}/`;
+            const comment = `🚀 Preview deployed to: ${previewUrl}`;
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: owner,
+              repo: repoName,
+              issue_number: prNumber
+            });
+            
+            const botComment = comments.find(c => 
+              c.user.login === 'github-actions[bot]' && c.body.includes('Preview deployed to:')
+            );
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: owner,
+                repo: repoName,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: owner,
+                repo: repoName,
+                issue_number: prNumber,
+                body: comment
+              });
+            }

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -22,9 +22,14 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            observability-ui/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          cd observability-ui && npm ci
 
       - name: Determine base path
         id: base_path

--- a/observability-ui/src/routes/+layout.ts
+++ b/observability-ui/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const trailingSlash = 'always';

--- a/observability-ui/svelte.config.js
+++ b/observability-ui/svelte.config.js
@@ -1,12 +1,21 @@
 import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	preprocess: vitePreprocess(),
 	compilerOptions: {
 		// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
 		runes: ({ filename }) => filename.split(/[/\\]/).includes('node_modules') ? undefined : true
 	},
-	kit: { adapter: adapter() }
+	kit: {
+		adapter: adapter({
+			fallback: '404.html'
+		}),
+		paths: {
+			base: process.env.PUBLIC_BASE_PATH || ''
+		}
+	}
 };
 
 export default config;


### PR DESCRIPTION
This PR sets up automated deployment of the Observability UI to GitHub Pages.

### Changes:
- Configured SvelteKit for static deployment with base path support.
- Added GitHub Actions workflow for automatic deployment to `gh-pages` branch.
- Enabled PR previews in subdirectories with automated PR comments.
- Verified build and base path configuration.

Fixes #70