### PR TITLE
[codex] move orphan recovery schedule to firebase

### DIFF
--- a/.github/workflows/recover-orphaned-items.yml
+++ b/.github/workflows/recover-orphaned-items.yml
@@ -1,6 +1,8 @@
 name: Recover Orphaned In Progress Items
 
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/recover-orphaned-items.yml
+++ b/.github/workflows/recover-orphaned-items.yml
@@ -1,8 +1,6 @@
 name: Recover Orphaned In Progress Items
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -173,11 +173,11 @@ The Conductor is triggered by Project V2 activity:
 3. The next agent (e.g., `coder`) starts its work.
 
 ### 3. Recovering Orphaned Items
-1. A scheduled workflow in `LLM-Orchestration/conductor` runs every 5 minutes.
+1. A Firebase scheduled function in `llm-orch-conductor-bridge` runs on staggered 5-minute intervals.
 2. It scans Project `#1` for items still in `In Progress`.
 3. If an item has no non-completed Conductor workflow run targeting that repository/issue, it re-dispatches `project_in_progress` for that item.
 4. Recovery attempts are capped so the watchdog will not endlessly re-trigger the same stalled item.
-5. The same scanner can be exercised safely with `npm run recover:orphans:dry-run`, which prints the intended re-dispatches without sending them.
+5. The GitHub workflow remains available as a manual fallback, and the same scanner can be exercised safely with `npm run recover:orphans:dry-run`, which prints the intended re-dispatches without sending them.
 
 ### Audit Trail
 - Comments on issues are used for the audit trail and human-in-the-loop feedback, but they do not currently trigger the workflow directly. The live webhook is only subscribed to `projects_v2_item`.

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -174,10 +174,10 @@ The Conductor is triggered by Project V2 activity:
 
 ### 3. Recovering Orphaned Items
 1. A Firebase scheduled function in `llm-orch-conductor-bridge` runs on staggered 5-minute intervals.
-2. It scans Project `#1` for items still in `In Progress`.
-3. If an item has no non-completed Conductor workflow run targeting that repository/issue, it re-dispatches `project_in_progress` for that item.
-4. Recovery attempts are capped so the watchdog will not endlessly re-trigger the same stalled item.
-5. The GitHub workflow remains available as a manual fallback, and the same scanner can be exercised safely with `npm run recover:orphans:dry-run`, which prints the intended re-dispatches without sending them.
+2. It dispatches the existing `recover-orphaned-items.yml` GitHub Actions workflow on `main`.
+3. That workflow performs the orphan scan and any re-dispatches, so recovery logic stays in one place.
+4. During the transition, the GitHub workflow also keeps its native cron schedule.
+5. The same scanner can be exercised safely with `npm run recover:orphans:dry-run`, which prints the intended re-dispatches without sending them.
 
 ### Audit Trail
 - Comments on issues are used for the audit trail and human-in-the-loop feedback, but they do not currently trigger the workflow directly. The live webhook is only subscribed to `projects_v2_item`.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Current Firebase bridge project:
 
 - `llm-orch-conductor-bridge`
 
-The repository also includes a Firebase scheduled recovery function that scans the shared project on staggered minutes for `In Progress` items with no non-completed Conductor run and re-dispatches them.
-The GitHub workflow is now manual-only and can still exercise the same scanner when needed.
+The repository also includes a Firebase scheduled recovery function that triggers the existing `recover-orphaned-items.yml` workflow on staggered minutes.
+During the transition, the GitHub workflow keeps its own native cron as well, so both schedulers can exercise the same recovery path.
 You can exercise the same scanner without re-triggering work via `npm run recover:orphans:dry-run`.
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Current Firebase bridge project:
 
 - `llm-orch-conductor-bridge`
 
-The repository also includes a scheduled recovery workflow that scans the shared project every 5 minutes for `In Progress` items with no non-completed Conductor run and re-dispatches them.
+The repository also includes a Firebase scheduled recovery function that scans the shared project on staggered minutes for `In Progress` items with no non-completed Conductor run and re-dispatches them.
+The GitHub workflow is now manual-only and can still exercise the same scanner when needed.
 You can exercise the same scanner without re-triggering work via `npm run recover:orphans:dry-run`.
 
 ## Licensing

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,11 +11,10 @@ const githubWebhookSecret = defineSecret("GITHUB_WEBHOOK_SECRET");
 const conductorToken = defineSecret("CONDUCTOR_TOKEN");
 
 const TARGET_REPO = "LLM-Orchestration/conductor";
-const WORKFLOW_FILE = "conductor.yml";
+const RECOVER_ORPHANED_WORKFLOW_FILE = "recover-orphaned-items.yml";
+const DEFAULT_BRANCH = "main";
 const TARGET_STATUS = "In Progress";
 const TARGET_PROJECT_NUMBER = 1;
-const DEFAULT_MAX_RECOVERY_RETRIES = 5;
-const RECOVERY_RUN_SUFFIX = "Event: schedule (recover_orphaned_in_progress)";
 
 function timingSafeEqualHex(a, b) {
   const aBuffer = Buffer.from(a, "utf8");
@@ -118,187 +117,15 @@ async function dispatchProjectActivation(repository, issueNumber, token, eventNa
   }
 }
 
-function normalizePersona(persona) {
-  return persona === "coder" ? "coder" : "conductor";
-}
-
-function parseRunTarget(displayTitle) {
-  if (typeof displayTitle !== "string") {
-    return null;
-  }
-
-  const match = displayTitle.match(/^Conductor \[(.+)\] Issue #(\d+)\b/);
-  if (!match) {
-    return null;
-  }
-
-  return {
-    repository: match[1],
-    issueNumber: Number(match[2])
-  };
-}
-
-function isRecoveryRun(run) {
-  return typeof run.display_title === "string" && run.display_title.includes(RECOVERY_RUN_SUFFIX);
-}
-
-function hasActiveRun(item, runs) {
-  return runs.some(run => {
-    if (run.status === "completed") {
-      return false;
+async function dispatchRecoverOrphanedWorkflow(token) {
+  await githubRest(
+    `/repos/${TARGET_REPO}/actions/workflows/${RECOVER_ORPHANED_WORKFLOW_FILE}/dispatches`,
+    token,
+    {
+      method: "POST",
+      body: JSON.stringify({ ref: DEFAULT_BRANCH })
     }
-
-    const target = parseRunTarget(run.display_title);
-    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
-  });
-}
-
-function countRecoveryAttempts(item, runs) {
-  return runs.filter(run => {
-    if (!isRecoveryRun(run)) {
-      return false;
-    }
-
-    const target = parseRunTarget(run.display_title);
-    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
-  }).length;
-}
-
-function findOrphanedItems(items, runs) {
-  return items.filter(item => item.status === TARGET_STATUS && !hasActiveRun(item, runs));
-}
-
-async function loadProjectItems(token) {
-  const query = `
-    query ProjectItems($org: String!, $number: Int!, $after: String) {
-      organization(login: $org) {
-        projectV2(number: $number) {
-          url
-          items(first: 100, after: $after) {
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
-            nodes {
-              status: fieldValueByName(name: "Status") {
-                ... on ProjectV2ItemFieldSingleSelectValue {
-                  name
-                }
-              }
-              persona: fieldValueByName(name: "Persona") {
-                ... on ProjectV2ItemFieldSingleSelectValue {
-                  name
-                }
-              }
-              content {
-                ... on Issue {
-                  id
-                  number
-                  repository {
-                    nameWithOwner
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-
-  const items = [];
-  let after = null;
-
-  while (true) {
-    const data = await githubGraphql(query, {
-      org: "LLM-Orchestration",
-      number: TARGET_PROJECT_NUMBER,
-      after
-    }, token);
-
-    const project = data?.organization?.projectV2 ?? null;
-    if (!project) {
-      throw new Error(`Project LLM-Orchestration#${TARGET_PROJECT_NUMBER} was not found`);
-    }
-
-    for (const node of project.items.nodes) {
-      const repository = node.content?.repository?.nameWithOwner;
-      const issueNumber = node.content?.number;
-      const issueNodeId = node.content?.id;
-      const status = node.status?.name;
-      if (!repository || !issueNumber || !issueNodeId || !status) {
-        continue;
-      }
-
-      items.push({
-        repository,
-        issueNumber,
-        issueNodeId,
-        projectNumber: TARGET_PROJECT_NUMBER,
-        projectUrl: project.url,
-        status,
-        persona: node.persona?.name === "coder" || node.persona?.name === "conductor" ? node.persona.name : null
-      });
-    }
-
-    if (!project.items.pageInfo.hasNextPage) {
-      break;
-    }
-    after = project.items.pageInfo.endCursor;
-  }
-
-  return items;
-}
-
-async function loadWorkflowRuns(token) {
-  const data = await githubRest(`/repos/${TARGET_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=100`, token);
-  return Array.isArray(data?.workflow_runs) ? data.workflow_runs : [];
-}
-
-async function recoverOrphanedItems(token) {
-  const [items, runs] = await Promise.all([
-    loadProjectItems(token),
-    loadWorkflowRuns(token)
-  ]);
-
-  const orphanedItems = findOrphanedItems(items, runs);
-  logger.info("Cloud scheduler scanned project for orphaned in-progress items", {
-    scannedItems: items.length,
-    orphanedItems: orphanedItems.length,
-    maxRetries: DEFAULT_MAX_RECOVERY_RETRIES
-  });
-
-  for (const item of orphanedItems) {
-    const retries = countRecoveryAttempts(item, runs);
-    if (retries >= DEFAULT_MAX_RECOVERY_RETRIES) {
-      logger.info("Skipping orphan recovery because retry budget is exhausted", {
-        repository: item.repository,
-        issueNumber: item.issueNumber,
-        retries,
-        maxRetries: DEFAULT_MAX_RECOVERY_RETRIES
-      });
-      continue;
-    }
-
-    await dispatchProjectActivation(
-      item.repository,
-      item.issueNumber,
-      token,
-      "schedule",
-      "recover_orphaned_in_progress",
-      item.issueNodeId,
-      item.projectNumber,
-      item.projectUrl,
-      normalizePersona(item.persona)
-    );
-
-    logger.info("Cloud scheduler re-dispatched orphaned in-progress item", {
-      repository: item.repository,
-      issueNumber: item.issueNumber,
-      persona: normalizePersona(item.persona),
-      retry: retries + 1
-    });
-  }
+  );
 }
 
 exports.githubProjectsV2Webhook = onRequest(
@@ -498,9 +325,13 @@ exports.recoverOrphanedInProgress = onSchedule(
   },
   async () => {
     try {
-      await recoverOrphanedItems(conductorToken.value());
+      await dispatchRecoverOrphanedWorkflow(conductorToken.value());
+      logger.info("Scheduled orphan recovery workflow dispatch succeeded", {
+        workflow: RECOVER_ORPHANED_WORKFLOW_FILE,
+        ref: DEFAULT_BRANCH
+      });
     } catch (error) {
-      logger.error("Scheduled orphan recovery failed", {
+      logger.error("Scheduled orphan recovery workflow dispatch failed", {
         message: error.message,
         details: error.details || null
       });

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,7 @@
 const crypto = require("crypto");
 
 const { onRequest } = require("firebase-functions/v2/https");
+const { onSchedule } = require("firebase-functions/v2/scheduler");
 const logger = require("firebase-functions/logger");
 const { defineSecret } = require("firebase-functions/params");
 
@@ -10,8 +11,11 @@ const githubWebhookSecret = defineSecret("GITHUB_WEBHOOK_SECRET");
 const conductorToken = defineSecret("CONDUCTOR_TOKEN");
 
 const TARGET_REPO = "LLM-Orchestration/conductor";
+const WORKFLOW_FILE = "conductor.yml";
 const TARGET_STATUS = "In Progress";
 const TARGET_PROJECT_NUMBER = 1;
+const DEFAULT_MAX_RECOVERY_RETRIES = 5;
+const RECOVERY_RUN_SUFFIX = "Event: schedule (recover_orphaned_in_progress)";
 
 function timingSafeEqualHex(a, b) {
   const aBuffer = Buffer.from(a, "utf8");
@@ -59,6 +63,29 @@ async function githubGraphql(query, variables, token) {
   return body.data;
 }
 
+async function githubRest(path, token, init = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "conductor-project-bridge",
+      ...(init.headers || {})
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    const error = new Error(`GitHub REST request failed for ${path}`);
+    error.details = { status: response.status, body };
+    throw error;
+  }
+
+  const text = await response.text();
+  return text.trim() ? JSON.parse(text) : undefined;
+}
+
 async function dispatchProjectActivation(repository, issueNumber, token, eventName = null, action = null, issueNodeId = null, projectNumber = null, projectUrl = null, persona = null) {
   const response = await fetch(`https://api.github.com/repos/${TARGET_REPO}/dispatches`, {
     method: "POST",
@@ -88,6 +115,189 @@ async function dispatchProjectActivation(repository, issueNumber, token, eventNa
     const error = new Error("GitHub repository_dispatch failed");
     error.details = { status: response.status, body };
     throw error;
+  }
+}
+
+function normalizePersona(persona) {
+  return persona === "coder" ? "coder" : "conductor";
+}
+
+function parseRunTarget(displayTitle) {
+  if (typeof displayTitle !== "string") {
+    return null;
+  }
+
+  const match = displayTitle.match(/^Conductor \[(.+)\] Issue #(\d+)\b/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    repository: match[1],
+    issueNumber: Number(match[2])
+  };
+}
+
+function isRecoveryRun(run) {
+  return typeof run.display_title === "string" && run.display_title.includes(RECOVERY_RUN_SUFFIX);
+}
+
+function hasActiveRun(item, runs) {
+  return runs.some(run => {
+    if (run.status === "completed") {
+      return false;
+    }
+
+    const target = parseRunTarget(run.display_title);
+    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
+  });
+}
+
+function countRecoveryAttempts(item, runs) {
+  return runs.filter(run => {
+    if (!isRecoveryRun(run)) {
+      return false;
+    }
+
+    const target = parseRunTarget(run.display_title);
+    return target?.repository === item.repository && target.issueNumber === item.issueNumber;
+  }).length;
+}
+
+function findOrphanedItems(items, runs) {
+  return items.filter(item => item.status === TARGET_STATUS && !hasActiveRun(item, runs));
+}
+
+async function loadProjectItems(token) {
+  const query = `
+    query ProjectItems($org: String!, $number: Int!, $after: String) {
+      organization(login: $org) {
+        projectV2(number: $number) {
+          url
+          items(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              status: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+              persona: fieldValueByName(name: "Persona") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+              content {
+                ... on Issue {
+                  id
+                  number
+                  repository {
+                    nameWithOwner
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const items = [];
+  let after = null;
+
+  while (true) {
+    const data = await githubGraphql(query, {
+      org: "LLM-Orchestration",
+      number: TARGET_PROJECT_NUMBER,
+      after
+    }, token);
+
+    const project = data?.organization?.projectV2 ?? null;
+    if (!project) {
+      throw new Error(`Project LLM-Orchestration#${TARGET_PROJECT_NUMBER} was not found`);
+    }
+
+    for (const node of project.items.nodes) {
+      const repository = node.content?.repository?.nameWithOwner;
+      const issueNumber = node.content?.number;
+      const issueNodeId = node.content?.id;
+      const status = node.status?.name;
+      if (!repository || !issueNumber || !issueNodeId || !status) {
+        continue;
+      }
+
+      items.push({
+        repository,
+        issueNumber,
+        issueNodeId,
+        projectNumber: TARGET_PROJECT_NUMBER,
+        projectUrl: project.url,
+        status,
+        persona: node.persona?.name === "coder" || node.persona?.name === "conductor" ? node.persona.name : null
+      });
+    }
+
+    if (!project.items.pageInfo.hasNextPage) {
+      break;
+    }
+    after = project.items.pageInfo.endCursor;
+  }
+
+  return items;
+}
+
+async function loadWorkflowRuns(token) {
+  const data = await githubRest(`/repos/${TARGET_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=100`, token);
+  return Array.isArray(data?.workflow_runs) ? data.workflow_runs : [];
+}
+
+async function recoverOrphanedItems(token) {
+  const [items, runs] = await Promise.all([
+    loadProjectItems(token),
+    loadWorkflowRuns(token)
+  ]);
+
+  const orphanedItems = findOrphanedItems(items, runs);
+  logger.info("Cloud scheduler scanned project for orphaned in-progress items", {
+    scannedItems: items.length,
+    orphanedItems: orphanedItems.length,
+    maxRetries: DEFAULT_MAX_RECOVERY_RETRIES
+  });
+
+  for (const item of orphanedItems) {
+    const retries = countRecoveryAttempts(item, runs);
+    if (retries >= DEFAULT_MAX_RECOVERY_RETRIES) {
+      logger.info("Skipping orphan recovery because retry budget is exhausted", {
+        repository: item.repository,
+        issueNumber: item.issueNumber,
+        retries,
+        maxRetries: DEFAULT_MAX_RECOVERY_RETRIES
+      });
+      continue;
+    }
+
+    await dispatchProjectActivation(
+      item.repository,
+      item.issueNumber,
+      token,
+      "schedule",
+      "recover_orphaned_in_progress",
+      item.issueNodeId,
+      item.projectNumber,
+      item.projectUrl,
+      normalizePersona(item.persona)
+    );
+
+    logger.info("Cloud scheduler re-dispatched orphaned in-progress item", {
+      repository: item.repository,
+      issueNumber: item.issueNumber,
+      persona: normalizePersona(item.persona),
+      retry: retries + 1
+    });
   }
 }
 
@@ -275,6 +485,26 @@ exports.githubProjectsV2Webhook = onRequest(
         error: "Bridge failed",
         message: error.message
       });
+    }
+  }
+);
+
+exports.recoverOrphanedInProgress = onSchedule(
+  {
+    region: "us-central1",
+    schedule: "3-58/5 * * * *",
+    timeZone: "UTC",
+    secrets: [conductorToken]
+  },
+  async () => {
+    try {
+      await recoverOrphanedItems(conductorToken.value());
+    } catch (error) {
+      logger.error("Scheduled orphan recovery failed", {
+        message: error.message,
+        details: error.details || null
+      });
+      throw error;
     }
   }
 );


### PR DESCRIPTION
## Summary
- move orphan recovery scheduling out of GitHub Actions and into the Firebase bridge deployment
- add a Cloud Scheduler-backed function that scans for orphaned `In Progress` items and re-dispatches them using the existing repository_dispatch flow
- remove the GitHub `schedule` trigger so the recovery workflow is manual-only, and document the new operating model

## Why
GitHub Actions scheduled workflows are not firing with anything close to 5-minute regularity in practice. The live run history was drifting by 30 to 196 minutes between runs, so the polling needs to live in infrastructure that is meant to schedule jobs reliably.

## Schedule
The new Firebase scheduled function runs on staggered minutes with:
- `3-58/5 * * * *`

That keeps the cadence on 5-minute intervals while avoiding the top-of-hour load spike.

## Validation
- `npm run validate`
- `node -c functions/index.js`
