### PR TITLE
Prepare Gemini auth in conductor workflow

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -76,13 +76,19 @@ jobs:
         working-directory: .conductor
         run: npm run build
 
+      - name: Prepare Gemini Auth
+        working-directory: .conductor
+        env:
+          GEMINI_API_KEY_SECRET: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_OAUTH_CREDS_JSON: ${{ secrets.GEMINI_OAUTH_CREDS_JSON }}
+        run: npm run gemini:prepare-auth
+
       - name: Run Conductor
         working-directory: .conductor
         env:
           CONDUCTOR_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
           GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_REPOSITORY: ${{ steps.metadata.outputs.repository }}
         run: npm start

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Conductor aims for extreme simplicity and high agency. Instead of complex, hardc
 
 This MVP invokes the official Gemini CLI through `npx` in headless mode.
 
-- For GitHub Actions, set the repository secret `GEMINI_API_KEY`.
-- For local runs, copy `.env.example` to `.env` and set `GEMINI_API_KEY`.
+- For GitHub Actions, set either:
+  - `GEMINI_OAUTH_CREDS_JSON` to the full contents of `~/.gemini/oauth_creds.json`
+  - or `GEMINI_API_KEY` as a fallback
+- The conductor workflow pre-seeds `~/.gemini/projects.json` on the runner to avoid the upstream `ProjectRegistry.save()` bootstrap race on fresh environments.
+- For local runs, either authenticate Gemini CLI so `~/.gemini/oauth_creds.json` exists, or copy `.env.example` to `.env` and set `GEMINI_API_KEY`.
 
 ## Projects V2 Setup
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "npm run build",
     "firebase:deploy": "npx --yes firebase-tools deploy --only functions",
     "firebase:serve": "npx --yes firebase-tools emulators:start --only functions",
+    "gemini:prepare-auth": "bash ./scripts/prepare-gemini-auth.sh",
     "human-review": "bash ./scripts/move-to-human-review.sh",
     "recover:orphans": "node dist/recover-orphans.js",
     "recover:orphans:dry-run": "node dist/recover-orphans.js --dry-run",

--- a/scripts/prepare-gemini-auth.sh
+++ b/scripts/prepare-gemini-auth.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+gemini_dir="${HOME:?HOME is required}/.gemini"
+mkdir -p "$gemini_dir"
+
+if [ ! -f "$gemini_dir/projects.json" ]; then
+  printf '{"projects":{}}\n' > "$gemini_dir/projects.json"
+fi
+
+if [ -n "${GEMINI_OAUTH_CREDS_JSON:-}" ]; then
+  node -e 'JSON.parse(process.env.GEMINI_OAUTH_CREDS_JSON || "")'
+  printf '%s' "$GEMINI_OAUTH_CREDS_JSON" > "$gemini_dir/oauth_creds.json"
+  chmod 600 "$gemini_dir/oauth_creds.json"
+  echo "Using Gemini OAuth credentials from GEMINI_OAUTH_CREDS_JSON."
+  exit 0
+fi
+
+if [ -n "${GEMINI_API_KEY_SECRET:-}" ]; then
+  if [ -z "${GITHUB_ENV:-}" ]; then
+    echo "GITHUB_ENV is required to forward GEMINI_API_KEY_SECRET." >&2
+    exit 1
+  fi
+
+  echo "GEMINI_API_KEY=$GEMINI_API_KEY_SECRET" >> "$GITHUB_ENV"
+  echo "Using Gemini API key from GEMINI_API_KEY."
+  exit 0
+fi
+
+echo "Neither GEMINI_OAUTH_CREDS_JSON nor GEMINI_API_KEY is configured." >&2
+exit 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,23 @@ function buildGeminiEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+function hasGeminiOAuthCredentials(): boolean {
+  const home = process.env.HOME;
+  if (!home) return false;
+
+  const credsPath = path.join(home, '.gemini', 'oauth_creds.json');
+
+  try {
+    const raw = fs.readFileSync(credsPath, 'utf8').trim();
+    if (!raw) return false;
+
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null;
+  } catch {
+    return false;
+  }
+}
+
 function loadIssueState(repository: string, issueNumber: number): { 
   labels: string[]; 
   body: string; 
@@ -403,8 +420,11 @@ ${commentBody}
 `;
 
     const geminiApiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
-    if (!geminiApiKey) {
-      console.error('Gemini API key not set. Configure GEMINI_API_KEY in GitHub Actions secrets or a local .env file.');
+    if (!geminiApiKey && !hasGeminiOAuthCredentials()) {
+      console.error(
+        'Gemini auth not set. Configure GEMINI_API_KEY or GEMINI_OAUTH_CREDS_JSON in GitHub Actions, ' +
+        'or authenticate locally so ~/.gemini/oauth_creds.json exists.'
+      );
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- pre-seed `~/.gemini/projects.json` on the Actions runner before Gemini starts
- support `GEMINI_OAUTH_CREDS_JSON` in CI and fall back to `GEMINI_API_KEY`
- allow conductor to run with local Gemini OAuth creds instead of requiring an API key

## Testing
- npm run validate
- smoke-tested `npm run gemini:prepare-auth` with dummy API-key and OAuth inputs