### PR TITLE
fix: OAuth exchange 400 error

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -336,21 +336,29 @@ exports.githubOAuthExchange = onRequest(
       return;
     }
 
+    logger.info("Starting GitHub OAuth exchange", { code: code.substring(0, 5) + "..." });
+
     try {
+      const params = new URLSearchParams();
+      params.append("client_id", githubClientId.value());
+      params.append("client_secret", githubClientSecret.value());
+      params.append("code", code);
+
       const response = await fetch("https://github.com/login/oauth/access_token", {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
           Accept: "application/json"
         },
-        body: JSON.stringify({
-          client_id: githubClientId.value(),
-          client_secret: githubClientSecret.value(),
-          code
-        })
+        body: params.toString()
       });
 
       const data = await response.json();
+      logger.info("GitHub OAuth exchange response received", { 
+        has_token: !!data.access_token,
+        error: data.error || null 
+      });
+
       if (data.error) {
         logger.error("GitHub OAuth exchange error", data);
         res.status(400).json(data);

--- a/observability-ui/src/routes/auth/callback/+page.svelte
+++ b/observability-ui/src/routes/auth/callback/+page.svelte
@@ -4,9 +4,12 @@
 	import { goto } from '$app/navigation';
 	import { PUBLIC_OAUTH_EXCHANGE_URL } from '$env/static/public';
 
+	let exchanged = false;
+
 	onMount(async () => {
 		const code = $page.url.searchParams.get('code');
-		if (code) {
+		if (code && !exchanged) {
+			exchanged = true;
 			try {
 				const response = await fetch(PUBLIC_OAUTH_EXCHANGE_URL, {
 					method: 'POST',


### PR DESCRIPTION
This PR fixes the 400 error during GitHub OAuth exchange by:
1. Updating the functions backend to use 'application/x-www-form-urlencoded' for the GitHub exchange request.
2. Adding an 'exchanged' guard in the frontend callback to prevent multiple exchange attempts on mount.
3. Adding logging to the backend for easier debugging.

Verified with E2E test: tests/e2e/003-oauth-flow/003-scenario.spec.ts