### PR TITLE
Issue #84: Prepend header to LLM comments

### DIFF
--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -67,7 +67,14 @@ fi
 
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
-cat > "$body_file"
+
+if [ -n "${CONDUCTOR_PERSONA:-}" ] && [ -n "${CONDUCTOR_LAST_COMMENT_URL:-}" ]; then
+  comment_id="${CONDUCTOR_LAST_COMMENT_URL##*-}"
+  echo "I am the $CONDUCTOR_PERSONA, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch $branch_name." > "$body_file"
+  echo "" >> "$body_file"
+fi
+
+cat >> "$body_file"
 
 if [ ! -s "$body_file" ]; then
   echo "Comment body must be provided on stdin" >&2

--- a/scripts/move-to-human-review.sh
+++ b/scripts/move-to-human-review.sh
@@ -101,8 +101,15 @@ fi
 body_file="$(mktemp)"
 trap 'rm -f "$body_file"' EXIT
 
+if [ -n "${CONDUCTOR_PERSONA:-}" ] && [ -n "${CONDUCTOR_LAST_COMMENT_URL:-}" ]; then
+  branch_name="$(git branch --show-current)"
+  comment_id="${CONDUCTOR_LAST_COMMENT_URL##*-}"
+  echo "I am the $CONDUCTOR_PERSONA, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch ${branch_name:-unknown}." > "$body_file"
+  echo "" >> "$body_file"
+fi
+
 if [ ! -t 0 ]; then
-  cat > "$body_file"
+  cat >> "$body_file"
 fi
 
 if [ -s "$body_file" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ function loadIssueState(repository: string, issueNumber: number): {
   labels: string[]; 
   body: string; 
   latestComment: string;
+  latestCommentUrl: string;
   commentCount: number;
   htmlUrl: string;
   nodeId: string;
@@ -136,15 +137,28 @@ function loadIssueState(repository: string, issueNumber: number): {
   const parsed = JSON.parse(issueData.stdout);
 
   // Fetch latest comment
-  const commentsData = spawnSync('gh', ['api', `repos/${repository}/issues/${issueNumber}/comments`, '--jq', '.[-1].body // empty'], {
+  const commentsData = spawnSync('gh', ['api', `repos/${repository}/issues/${issueNumber}/comments`, '--jq', '. [-1] | {body: .body, html_url: .html_url} // empty'], {
     encoding: 'utf8',
     env: process.env
   });
 
+  let latestComment = '';
+  let latestCommentUrl = '';
+  if (commentsData.status === 0 && commentsData.stdout.trim()) {
+    try {
+      const commentParsed = JSON.parse(commentsData.stdout);
+      latestComment = commentParsed.body || '';
+      latestCommentUrl = commentParsed.html_url || '';
+    } catch {
+      // ignore
+    }
+  }
+
   return {
     labels: Array.isArray(parsed.labels) ? parsed.labels.map((label: { name: string }) => label.name) : [],
     body: parsed.body || '',
-    latestComment: commentsData.status === 0 ? commentsData.stdout.trim() : '',
+    latestComment,
+    latestCommentUrl,
     commentCount: typeof parsed.comments === 'number' ? parsed.comments : 0,
     htmlUrl: parsed.html_url || '',
     nodeId: parsed.node_id || ''
@@ -307,6 +321,7 @@ async function main() {
     labels,
     issueBody,
     commentBody,
+    commentUrl,
     projectNumber,
     projectUrl,
     eventName: extractedEventName,
@@ -314,6 +329,7 @@ async function main() {
   } = extractEventData(event, process.env);
 
   let persona: 'conductor' | 'coder' | null = null;
+  let lastCommentUrl = commentUrl;
 
   try {
     if (!issueNumber) {
@@ -331,6 +347,7 @@ async function main() {
       labels = liveIssueState.labels;
       issueBody = liveIssueState.body;
       commentBody = liveIssueState.latestComment;
+      lastCommentUrl = liveIssueState.latestCommentUrl;
       issueUrl = liveIssueState.htmlUrl;
       issueNodeId = liveIssueState.nodeId;
       const commentLimit = getEffectiveCommentLimit(repository, issueNumber, liveIssueState.commentCount);
@@ -452,6 +469,8 @@ ENVIRONMENT:
 
     console.log('Invoking Gemini CLI...');
     const childEnv = buildGeminiEnv();
+    childEnv.CONDUCTOR_PERSONA = persona;
+    childEnv.CONDUCTOR_LAST_COMMENT_URL = lastCommentUrl;
     
     // The target repository is at the root (../ from .conductor/dist/src or ../ from .conductor if running via npm start)
     // In Actions, GITHUB_WORKSPACE is the root.

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -9,6 +9,7 @@ export interface GitHubEvent {
   };
   comment?: {
     body: string;
+    html_url?: string;
   };
   client_payload?: {
     repository?: string;
@@ -20,6 +21,7 @@ export interface GitHubEvent {
     persona?: string;
     event_name?: string;
     action?: string;
+    last_comment_url?: string;
   };
 }
 
@@ -31,6 +33,7 @@ export function extractEventData(event: GitHubEvent, env: NodeJS.ProcessEnv) {
   const labels = event.issue?.labels?.map(l => l.name) || [];
   const issueBody = event.issue?.body || '';
   const commentBody = event.comment?.body || '';
+  const commentUrl = event.comment?.html_url || event.client_payload?.last_comment_url || '';
   const projectNumber = event.client_payload?.project_number;
   const projectUrl = event.client_payload?.project_url;
   const eventName = event.client_payload?.event_name || env.GITHUB_EVENT_NAME || '';
@@ -44,6 +47,7 @@ export function extractEventData(event: GitHubEvent, env: NodeJS.ProcessEnv) {
     labels,
     issueBody,
     commentBody,
+    commentUrl,
     projectNumber,
     projectUrl,
     eventName,

--- a/tests/handoff_test.sh
+++ b/tests/handoff_test.sh
@@ -558,5 +558,54 @@ else
   exit 1
 fi
 
+# Test 11: Header prepending
+export CONDUCTOR_PERSONA="coder"
+export CONDUCTOR_LAST_COMMENT_URL="https://github.com/LLM-Orchestration/conductor/issues/123#issuecomment-456789"
+cat > "$GITHUB_EVENT_PATH" <<'EOF'
+{
+  "client_payload": {
+    "issue_number": 123
+  }
+}
+EOF
+cat > "$TEST_DIR/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "issue view"*".labels[].name"*)
+    echo "persona: conductor"
+    echo "branch: test-branch"
+    ;;
+  "issue view"*)
+    echo '{"labels":[{"name":"persona: conductor"}, {"name":"branch: test-branch"}]}'
+    ;;
+  "issue comment"*)
+    # Capture the body file content
+    while [ "\$#" -gt 0 ]; do
+      if [ "\$1" == "--body-file" ]; then
+        cp "\$2" "$TEST_DIR/captured_body.md"
+        break
+      fi
+      shift
+    done
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$TEST_DIR/gh"
+
+echo "Running handoff.sh (checking for header)..."
+echo "Original body" | bash scripts/handoff.sh conductor
+
+if grep -q "I am the coder, and I am responding to comment \[456789\](https://github.com/LLM-Orchestration/conductor/issues/123#issuecomment-456789) on branch test-branch." "$TEST_DIR/captured_body.md"; then
+  echo "Success: Header prepended correctly"
+else
+  echo "Error: Header NOT prepended correctly"
+  cat "$TEST_DIR/captured_body.md"
+  exit 1
+fi
+
 echo "All handoff validation tests passed!"
 exit 0

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -22,6 +22,34 @@ describe('extractEventData', () => {
     expect(result.issueBody).toBe('issue body');
   });
 
+  it('should extract commentUrl from issue_comment event', () => {
+    const event: GitHubEvent = {
+      issue: {
+        number: 123,
+        labels: [],
+        body: 'issue body',
+        html_url: 'https://github.com/owner/repo/issues/123'
+      },
+      comment: {
+        body: 'comment body',
+        html_url: 'https://github.com/owner/repo/issues/123#issuecomment-789'
+      }
+    };
+    const result = extractEventData(event, {});
+    expect(result.commentBody).toBe('comment body');
+    expect(result.commentUrl).toBe('https://github.com/owner/repo/issues/123#issuecomment-789');
+  });
+
+  it('should extract commentUrl from client_payload', () => {
+    const event: GitHubEvent = {
+      client_payload: {
+        last_comment_url: 'https://github.com/owner/repo/issues/123#issuecomment-456'
+      }
+    };
+    const result = extractEventData(event, {});
+    expect(result.commentUrl).toBe('https://github.com/owner/repo/issues/123#issuecomment-456');
+  });
+
   it('should extract data from repository_dispatch event with client_payload', () => {
     const event: GitHubEvent = {
       client_payload: {


### PR DESCRIPTION
This PR implements the requested feature to prepend a header to LLM comments identifying the persona, the comment being responded to, and the current branch.

### Changes:
- Updated `src/utils/github.ts` to extract comment URL.
- Updated `src/index.ts` to fetch latest comment URL and export environment variables.
- Modified `scripts/handoff.sh` and `scripts/move-to-human-review.sh` to prepend the header.
- Added tests to verify the header prepending logic.