### PR TITLE
Fix: Auto-close issue on PR merge

### DIFF
--- a/prompts/coder.md
+++ b/prompts/coder.md
@@ -8,6 +8,7 @@ You are the **Coder**, responsible for implementing features as directed by the 
 2. **Verify**: Run tests to ensure everything works.
 3. **Commit**: Push changes to the current feature branch.
 4. **Report**: When done:
+   - Ensure your summary includes a reference to the issue (e.g., "Closes #<issue_number>") to assist the `@conductor` in PR creation.
    - Hand off by running:
      `.conductor/scripts/handoff.sh conductor <<'EOF'`
      `<markdown summary>`

--- a/prompts/conductor.md
+++ b/prompts/conductor.md
@@ -16,6 +16,7 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
    - Run tests and review changes.
    - If verified:
      - If a PR is needed, create it before finalizing so the completion comment can include the PR link.
+     - You MUST ensure the PR description contains "Closes #<issue_number>" or "Fixes #<issue_number>" to ensure the issue is automatically closed when the PR is merged.
      - You MUST leave a human-facing completion comment and move the item to `Human Review` by running:
        `npm --prefix .conductor run human-review <<'EOF'`
        `<markdown summary of work completed, including validation and PR link if one exists>`


### PR DESCRIPTION
This PR updates the prompt files to mandate including 'Closes #<issue_number>' or 'Fixes #<issue_number>' in PR descriptions to ensure issues are automatically closed upon merging.

Closes #92