### PR TITLE
Handle validation failures on system-created PRs

### DIFF
--- a/.github/workflows/handle-pr-failure.yml
+++ b/.github/workflows/handle-pr-failure.yml
@@ -1,0 +1,43 @@
+name: Handle PR Failure
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request'
+    permissions:
+      issues: write
+      pull-requests: write
+      repository-projects: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Handle Failure
+        env:
+          GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Extract PR number from workflow_run event
+          PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+          
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            # Fallback: search for PR by head branch and SHA if not directly in the event
+            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "PR info not in event, searching for PR with head $HEAD_BRANCH and SHA $HEAD_SHA"
+            PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number,headRefOid --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number")
+          fi
+          
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            echo "Processing PR #$PR_NUMBER"
+            chmod +x ./scripts/handle-validation-failure.sh
+            ./scripts/handle-validation-failure.sh "$PR_NUMBER"
+          else
+            echo "Could not identify PR for this workflow run."
+          fi

--- a/scripts/handle-validation-failure.sh
+++ b/scripts/handle-validation-failure.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/handle-validation-failure.sh PR_NUMBER [REPOSITORY]
+
+PR_NUMBER="${1:-}"
+REPOSITORY="${2:-$GITHUB_REPOSITORY}"
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "Usage: $0 PR_NUMBER [REPOSITORY]" >&2
+  exit 1
+fi
+
+echo "Handling validation failure for PR #$PR_NUMBER in $REPOSITORY"
+
+# 1. Use gh pr view to get PR body and headRefName.
+PR_DATA=$(gh pr view "$PR_NUMBER" -R "$REPOSITORY" --json body,headRefName)
+PR_BODY=$(echo "$PR_DATA" | jq -r '.body')
+HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
+
+# 2. Extract parent issue number from the body (look for "Closes #...", "Fixes #...", "Resolves #...").
+# Supported patterns: Closes #123, Fixes #123, Resolves #123, etc.
+ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oEi '(closes|fixes|resolves) #[0-9]+' | head -n 1 | grep -oE '[0-9]+' || true)
+
+if [ -z "$ISSUE_NUMBER" ]; then
+  echo "Could not find parent issue number in PR #$PR_NUMBER body."
+  exit 0
+fi
+
+# 3. Identify if it's "system-created".
+# Identification: Consider a PR "system-created" if its branch name matches issue-[0-9]+ OR if the parent issue has a persona: label.
+IS_SYSTEM_CREATED=false
+if [[ "$HEAD_REF" =~ ^issue-[0-9]+$ ]]; then
+  IS_SYSTEM_CREATED=true
+fi
+
+ISSUE_LABELS=$(gh issue view "$ISSUE_NUMBER" -R "$REPOSITORY" --json labels --jq '.labels[].name')
+if echo "$ISSUE_LABELS" | grep -q "^persona:"; then
+  IS_SYSTEM_CREATED=true
+fi
+
+if [ "$IS_SYSTEM_CREATED" = "false" ]; then
+  echo "PR #$PR_NUMBER is not considered system-created. Skipping."
+  exit 0
+fi
+
+echo "Parent issue: #$ISSUE_NUMBER"
+
+# 4. Use gh issue view --json projectItems to find the project item and current status of the parent issue.
+# The project we are interested in is project number 1 ("Platform 10").
+PROJECT_NUMBER=1
+PROJECT_OWNER="LLM-Orchestration"
+
+# Note: projectItems is an array. We filter for the specific project number.
+# Using --jq to filter and extract status and other info.
+ITEM_DATA=$(gh issue view "$ISSUE_NUMBER" -R "$REPOSITORY" --json projectItems --jq ".projectItems[] | select(.project.number == $PROJECT_NUMBER)" | head -n 1)
+
+if [ -z "$ITEM_DATA" ]; then
+  echo "Parent issue #$ISSUE_NUMBER is not in project $PROJECT_NUMBER. Skipping project status update."
+else
+  # The jq path for status name might depend on gh version, but usually it's .status
+  # Let's try to be safe and use .statusValue if .status is not what we want, 
+  # but standard gh output for projectItems includes .status as the title of the status.
+  CURRENT_STATUS=$(echo "$ITEM_DATA" | jq -r '.status // empty')
+  
+  # 5. If the status is NOT "In Progress", move it back to "In Progress".
+  if [ "$CURRENT_STATUS" != "In Progress" ]; then
+    echo "Current status is '$CURRENT_STATUS'. Moving back to 'In Progress'."
+    
+    ITEM_ID=$(echo "$ITEM_DATA" | jq -r '.id')
+    PROJECT_ID=$(echo "$ITEM_DATA" | jq -r '.project.id')
+    
+    # We need field ID for "Status" and option ID for "In Progress"
+    FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)
+    STATUS_FIELD_ID=$(echo "$FIELDS_JSON" | jq -r '.fields[] | select(.name == "Status") | .id')
+    IN_PROGRESS_OPTION_ID=$(echo "$FIELDS_JSON" | jq -r ".fields[] | select(.name == \"Status\") | .options[] | select(.name == \"In Progress\") | .id")
+    
+    if [ -n "$STATUS_FIELD_ID" ] && [ -n "$IN_PROGRESS_OPTION_ID" ]; then
+      gh project item-edit \
+        --id "$ITEM_ID" \
+        --project-id "$PROJECT_ID" \
+        --field-id "$STATUS_FIELD_ID" \
+        --single-select-option-id "$IN_PROGRESS_OPTION_ID" > /dev/null
+      
+      echo "Moved issue #$ISSUE_NUMBER back to In Progress."
+    else
+      echo "Could not find Status field or In Progress option ID. Status field: $STATUS_FIELD_ID, Option: $IN_PROGRESS_OPTION_ID"
+    fi
+  else
+    echo "Issue #$ISSUE_NUMBER is already In Progress."
+  fi
+fi
+
+# 6. Post a comment on the parent issue.
+COMMENT_BODY="### ❌ Validation Failed on PR #$PR_NUMBER
+
+The validation workflows failed on the associated PR. This issue has been moved back to **In Progress** for further work.
+
+Please check the PR for details: [PR #$PR_NUMBER](https://github.com/$REPOSITORY/pull/$PR_NUMBER)"
+
+gh issue comment "$ISSUE_NUMBER" -R "$REPOSITORY" --body "$COMMENT_BODY"
+echo "Comment posted on issue #$ISSUE_NUMBER."

--- a/tests/handle-validation-failure_test.sh
+++ b/tests/handle-validation-failure_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests/handle-validation-failure_test.sh
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export PATH="$TEST_DIR:$PATH"
+export GITHUB_REPOSITORY="LLM-Orchestration/conductor"
+
+CALL_LOG="$TEST_DIR/gh_calls"
+touch "$CALL_LOG"
+
+# Mock gh command
+cat > "$TEST_DIR/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$CALL_LOG"
+case "\$*" in
+  "pr view 123 -R LLM-Orchestration/conductor --json body,headRefName")
+    echo '{"body": "Closes #456", "headRefName": "issue-456"}'
+    ;;
+  "issue view 456 -R LLM-Orchestration/conductor --json labels --jq .labels[].name")
+    echo "persona: coder"
+    echo "bug"
+    ;;
+  "issue view 456 -R LLM-Orchestration/conductor --json projectItems --jq .projectItems[] | select(.project.number == 1)")
+    echo '{"id": "item_node_id", "status": "Human Review", "project": {"id": "project_node_id", "number": 1}}'
+    ;;
+  "project field-list 1 --owner LLM-Orchestration --format json")
+    echo '{"fields": [{"name": "Status", "id": "status_field_id", "options": [{"name": "Todo", "id": "todo_id"}, {"name": "In Progress", "id": "in_progress_id"}]}]}'
+    ;;
+  "project item-edit --id item_node_id --project-id project_node_id --field-id status_field_id --single-select-option-id in_progress_id")
+    exit 0
+    ;;
+  "issue comment 456 -R LLM-Orchestration/conductor --body"*)
+    exit 0
+    ;;
+  *)
+    echo "Mock GH called with unexpected arguments: \$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$TEST_DIR/gh"
+
+echo "Running handle-validation-failure.sh test..."
+if bash scripts/handle-validation-failure.sh 123 LLM-Orchestration/conductor; then
+  echo "Script exited successfully."
+else
+  echo "Script failed!"
+  exit 1
+fi
+
+# Verify calls
+echo "Verifying gh calls..."
+
+if grep -q "gh project item-edit --id item_node_id --project-id project_node_id --field-id status_field_id --single-select-option-id in_progress_id" "$CALL_LOG"; then
+  echo "Success: project item-edit was called correctly"
+else
+  echo "Error: project item-edit was NOT called correctly"
+  cat "$CALL_LOG"
+  exit 1
+fi
+
+if grep -q "gh issue comment 456 -R LLM-Orchestration/conductor --body" "$CALL_LOG"; then
+  echo "Success: issue comment was called"
+else
+  echo "Error: issue comment was NOT called"
+  cat "$CALL_LOG"
+  exit 1
+fi
+
+echo "Test 1 passed: Successful move back to In Progress."
+
+# Test 2: Already In Progress (should NOT call project item-edit but SHOULD call issue comment)
+echo "" > "$CALL_LOG"
+cat > "$TEST_DIR/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$CALL_LOG"
+case "\$*" in
+  "pr view 124 -R LLM-Orchestration/conductor --json body,headRefName")
+    echo '{"body": "Resolves #457", "headRefName": "issue-457"}'
+    ;;
+  "issue view 457 -R LLM-Orchestration/conductor --json labels --jq .labels[].name")
+    echo "persona: conductor"
+    ;;
+  "issue view 457 -R LLM-Orchestration/conductor --json projectItems --jq .projectItems[] | select(.project.number == 1)")
+    echo '{"id": "item_node_id_2", "status": "In Progress", "project": {"id": "project_node_id", "number": 1}}'
+    ;;
+  "issue comment 457 -R LLM-Orchestration/conductor --body"*)
+    exit 0
+    ;;
+  *)
+    echo "Mock GH called with unexpected arguments: \$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+echo "Running Test 2: Already In Progress..."
+if bash scripts/handle-validation-failure.sh 124 LLM-Orchestration/conductor; then
+  echo "Script exited successfully."
+else
+  echo "Script failed!"
+  exit 1
+fi
+
+if grep -q "gh project item-edit" "$CALL_LOG"; then
+  echo "Error: project item-edit should NOT have been called"
+  exit 1
+else
+  echo "Success: project item-edit was not called"
+fi
+
+if grep -q "gh issue comment 457 -R LLM-Orchestration/conductor --body" "$CALL_LOG"; then
+  echo "Success: issue comment was called"
+else
+  echo "Error: issue comment was NOT called"
+  exit 1
+fi
+
+echo "Test 2 passed: Already In Progress handled correctly."
+
+echo "All tests passed!"
+exit 0


### PR DESCRIPTION
This PR implements the mechanism to handle validation failures on system-created pull requests.

### Changes:
1.  **Created `scripts/handle-validation-failure.sh`**:
    - Identifies parent issue from PR body (e.g., "Closes #123").
    - Determines if PR is "system-created" based on branch name (`issue-[0-9]+`) or parent issue labels (`persona:`).
    - Moves parent issue back to "In Progress" in the project board if it's currently in another state.
    - Posts a failure notification comment on the parent issue.
2.  **Created `.github/workflows/handle-pr-failure.yml`**:
    - Triggered by `workflow_run` of the `CI` workflow when it completes with failure on a `pull_request` event.
    - Extracts PR number and calls the handler script.
3.  **Added `tests/handle-validation-failure_test.sh`**:
    - Comprehensive test suite mocking `gh` to verify script logic.

Closes #95