### PR TITLE
feat: extract media URLs from issue and comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 
 import { runStreamingCommand } from './utils/exec';
 import { DEFAULT_COMMENT_LIMIT, resolveCommentLimit } from './utils/comment-limit';
-import { GitHubEvent, extractEventData, extractMediaUrls } from './utils/github';
+import { GitHubEvent, extractEventData, extractMediaUrls, collectAllMediaUrls } from './utils/github';
 import { logEvent, logger } from './utils/logger';
 
 function verifyGitHubCli(repository: string, issueNumber: number): string {
@@ -343,7 +343,7 @@ async function main() {
         issueUrl = liveIssueState.htmlUrl;
         issueNodeId = liveIssueState.nodeId;
 
-        if (liveIssueState.commentCount > DEFAULT_COMMENT_LIMIT) {
+        if (liveIssueState.commentCount > 0) {
           allCommentBodies = loadIssueCommentBodies(repository, issueNumber, liveIssueState.commentCount);
         }
 
@@ -458,11 +458,7 @@ ENVIRONMENT:
 - If a gh command fails, report the exact command and stderr instead of inferring an authentication problem.`;
 
     // Extract media URLs from issue body, latest comment, and any other loaded comments
-    const mediaUrls = new Set<string>([
-      ...extractMediaUrls(issueBody),
-      ...extractMediaUrls(commentBody),
-      ...allCommentBodies.flatMap(body => extractMediaUrls(body))
-    ]);
+    const mediaUrls = collectAllMediaUrls(issueBody, commentBody, allCommentBodies);
 
     // Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
     const args = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 
 import { runStreamingCommand } from './utils/exec';
 import { DEFAULT_COMMENT_LIMIT, resolveCommentLimit } from './utils/comment-limit';
-import { GitHubEvent, extractEventData } from './utils/github';
+import { GitHubEvent, extractEventData, extractMediaUrls } from './utils/github';
 import { logEvent, logger } from './utils/logger';
 
 function verifyGitHubCli(repository: string, issueNumber: number): string {
@@ -197,15 +197,6 @@ function loadIssueCommentBodies(repository: string, issueNumber: number, comment
   return bodies;
 }
 
-function getEffectiveCommentLimit(repository: string, issueNumber: number, commentCount: number): number {
-  if (commentCount <= DEFAULT_COMMENT_LIMIT) {
-    return DEFAULT_COMMENT_LIMIT;
-  }
-
-  const commentBodies = loadIssueCommentBodies(repository, issueNumber, commentCount);
-  return resolveCommentLimit(commentBodies, DEFAULT_COMMENT_LIMIT);
-}
-
 function moveToHumanReview(
   repository: string,
   issueNumber: number,
@@ -328,46 +319,55 @@ async function main() {
     action
   } = extractEventData(event, process.env);
 
-  let persona: 'conductor' | 'coder' | null = null;
-  let lastCommentUrl = commentUrl;
+    let persona: 'conductor' | 'coder' | null = null;
+    let lastCommentUrl = commentUrl;
+    let allCommentBodies: string[] = [];
 
-  try {
-    if (!issueNumber) {
-      logger.error('No issue number found in event');
-      process.exit(0);
-    }
-
-    if (!repository) {
-      logger.error('No repository found in event');
-      process.exit(1);
-    }
-
-    const liveIssueState = loadIssueState(repository, issueNumber);
-    if (liveIssueState) {
-      labels = liveIssueState.labels;
-      issueBody = liveIssueState.body;
-      commentBody = liveIssueState.latestComment;
-      lastCommentUrl = liveIssueState.latestCommentUrl;
-      issueUrl = liveIssueState.htmlUrl;
-      issueNodeId = liveIssueState.nodeId;
-      const commentLimit = getEffectiveCommentLimit(repository, issueNumber, liveIssueState.commentCount);
-      if (liveIssueState.commentCount > commentLimit) {
-        logger.info(
-          `Comment limit exceeded for ${repository}#${issueNumber} ` +
-          `(${liveIssueState.commentCount} > ${commentLimit}). Moving item to Human Review.`
-        );
-        moveToHumanReview(
-          repository,
-          issueNumber,
-          issueNodeId,
-          projectNumber ?? null,
-          projectUrl || '',
-          liveIssueState.commentCount,
-          commentLimit
-        );
+    try {
+      if (!issueNumber) {
+        logger.error('No issue number found in event');
         process.exit(0);
       }
-    }
+
+      if (!repository) {
+        logger.error('No repository found in event');
+        process.exit(1);
+      }
+
+      const liveIssueState = loadIssueState(repository, issueNumber);
+      if (liveIssueState) {
+        labels = liveIssueState.labels;
+        issueBody = liveIssueState.body;
+        commentBody = liveIssueState.latestComment;
+        lastCommentUrl = liveIssueState.latestCommentUrl;
+        issueUrl = liveIssueState.htmlUrl;
+        issueNodeId = liveIssueState.nodeId;
+
+        if (liveIssueState.commentCount > DEFAULT_COMMENT_LIMIT) {
+          allCommentBodies = loadIssueCommentBodies(repository, issueNumber, liveIssueState.commentCount);
+        }
+
+        const commentLimit = allCommentBodies.length > 0
+          ? resolveCommentLimit(allCommentBodies, DEFAULT_COMMENT_LIMIT)
+          : DEFAULT_COMMENT_LIMIT;
+
+        if (liveIssueState.commentCount > commentLimit) {
+          logger.info(
+            `Comment limit exceeded for ${repository}#${issueNumber} ` +
+            `(${liveIssueState.commentCount} > ${commentLimit}). Moving item to Human Review.`
+          );
+          moveToHumanReview(
+            repository,
+            issueNumber,
+            issueNodeId,
+            projectNumber ?? null,
+            projectUrl || '',
+            liveIssueState.commentCount,
+            commentLimit
+          );
+          process.exit(0);
+        }
+      }
 
     if (eventName === 'repository_dispatch' && !labels.some(label => label.startsWith('persona:'))) {
       const targetPersona = (event.client_payload?.persona === 'coder' || event.client_payload?.persona === 'conductor') 
@@ -457,6 +457,13 @@ ENVIRONMENT:
 - GitHub CLI repository access has been preflight-verified for ${verifiedRepo}.
 - If a gh command fails, report the exact command and stderr instead of inferring an authentication problem.`;
 
+    // Extract media URLs from issue body, latest comment, and any other loaded comments
+    const mediaUrls = new Set<string>([
+      ...extractMediaUrls(issueBody),
+      ...extractMediaUrls(commentBody),
+      ...allCommentBodies.flatMap(body => extractMediaUrls(body))
+    ]);
+
     // Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
     const args = [
       '-y',
@@ -466,6 +473,10 @@ ENVIRONMENT:
       '--approval-mode',
       'yolo'
     ];
+
+    for (const url of mediaUrls) {
+      args.push('--media', url);
+    }
 
     logger.info('Invoking Gemini CLI...');
     const childEnv = buildGeminiEnv();

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,8 +457,8 @@ ENVIRONMENT:
 - GitHub CLI repository access has been preflight-verified for ${verifiedRepo}.
 - If a gh command fails, report the exact command and stderr instead of inferring an authentication problem.`;
 
-    // Extract media URLs from issue body, latest comment, and any other loaded comments
-    const mediaUrls = collectAllMediaUrls(issueBody, commentBody, allCommentBodies);
+    // Extract media URLs from issue body and latest comment
+    const mediaUrls = collectAllMediaUrls(issueBody, commentBody);
 
     // Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
     const args = [

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -67,3 +67,19 @@ export function extractMediaUrls(text: string): string[] {
   if (!matches) return [];
   return [...new Set(matches)];
 }
+
+/**
+ * Collects all unique media URLs from issue body, latest comment, and all other comment bodies.
+ */
+export function collectAllMediaUrls(
+  issueBody: string,
+  latestCommentBody: string,
+  allCommentBodies: string[]
+): string[] {
+  const mediaUrls = new Set<string>([
+    ...extractMediaUrls(issueBody),
+    ...extractMediaUrls(latestCommentBody),
+    ...allCommentBodies.flatMap(body => extractMediaUrls(body))
+  ]);
+  return [...mediaUrls];
+}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -69,17 +69,15 @@ export function extractMediaUrls(text: string): string[] {
 }
 
 /**
- * Collects all unique media URLs from issue body, latest comment, and all other comment bodies.
+ * Collects all unique media URLs from issue body and latest comment.
  */
 export function collectAllMediaUrls(
   issueBody: string,
-  latestCommentBody: string,
-  allCommentBodies: string[]
+  latestCommentBody: string
 ): string[] {
   const mediaUrls = new Set<string>([
     ...extractMediaUrls(issueBody),
-    ...extractMediaUrls(latestCommentBody),
-    ...allCommentBodies.flatMap(body => extractMediaUrls(body))
+    ...extractMediaUrls(latestCommentBody)
   ]);
   return [...mediaUrls];
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -54,3 +54,16 @@ export function extractEventData(event: GitHubEvent, env: NodeJS.ProcessEnv) {
     action
   };
 }
+
+/**
+ * Extracts GitHub user-attachment URLs from a given text.
+ * @param text The text to scan for URLs.
+ * @returns An array of unique media URLs.
+ */
+export function extractMediaUrls(text: string): string[] {
+  if (!text) return [];
+  const regex = /https:\/\/github\.com\/user-attachments\/assets\/[0-9a-fA-F-]+/g;
+  const matches = text.match(regex);
+  if (!matches) return [];
+  return [...new Set(matches)];
+}

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect } from 'vitest';
-import { extractEventData, GitHubEvent } from '../../src/utils/github';
+import { extractEventData, GitHubEvent, extractMediaUrls } from '../../src/utils/github';
+
+describe('extractMediaUrls', () => {
+  it('should extract multiple URLs from text', () => {
+    const text = 'Here are some images: https://github.com/user-attachments/assets/3c27f0cf-ed52-489a-bb2f-25f1f06891c8 and https://github.com/user-attachments/assets/12345678-1234-1234-1234-1234567890ab';
+    const result = extractMediaUrls(text);
+    expect(result).toEqual([
+      'https://github.com/user-attachments/assets/3c27f0cf-ed52-489a-bb2f-25f1f06891c8',
+      'https://github.com/user-attachments/assets/12345678-1234-1234-1234-1234567890ab'
+    ]);
+  });
+
+  it('should de-duplicate URLs', () => {
+    const text = 'Duplicate: https://github.com/user-attachments/assets/3c27f0cf-ed52-489a-bb2f-25f1f06891c8 and https://github.com/user-attachments/assets/3c27f0cf-ed52-489a-bb2f-25f1f06891c8';
+    const result = extractMediaUrls(text);
+    expect(result).toEqual(['https://github.com/user-attachments/assets/3c27f0cf-ed52-489a-bb2f-25f1f06891c8']);
+  });
+
+  it('should return empty array if no URLs found', () => {
+    const text = 'No URLs here';
+    const result = extractMediaUrls(text);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for empty or null input', () => {
+    expect(extractMediaUrls('')).toEqual([]);
+    expect(extractMediaUrls(null as unknown as string)).toEqual([]);
+  });
+});
 
 describe('extractEventData', () => {
   it('should extract data from issue event', () => {

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractEventData, GitHubEvent, extractMediaUrls } from '../../src/utils/github';
+import { extractEventData, GitHubEvent, extractMediaUrls, collectAllMediaUrls } from '../../src/utils/github';
 
 describe('extractMediaUrls', () => {
   it('should extract multiple URLs from text', () => {
@@ -26,6 +26,29 @@ describe('extractMediaUrls', () => {
   it('should return empty array for empty or null input', () => {
     expect(extractMediaUrls('')).toEqual([]);
     expect(extractMediaUrls(null as unknown as string)).toEqual([]);
+  });
+});
+
+describe('collectAllMediaUrls', () => {
+  it('should collect unique URLs from all sources', () => {
+    const issueBody = 'Issue: https://github.com/user-attachments/assets/1';
+    const latestComment = 'Latest: https://github.com/user-attachments/assets/2';
+    const allComments = [
+      'Comment 1: https://github.com/user-attachments/assets/1', // duplicate from issue
+      'Comment 2: https://github.com/user-attachments/assets/3'
+    ];
+
+    const result = collectAllMediaUrls(issueBody, latestComment, allComments);
+    expect(result.sort()).toEqual([
+      'https://github.com/user-attachments/assets/1',
+      'https://github.com/user-attachments/assets/2',
+      'https://github.com/user-attachments/assets/3'
+    ].sort());
+  });
+
+  it('should handle empty sources', () => {
+    const result = collectAllMediaUrls('', '', []);
+    expect(result).toEqual([]);
   });
 });
 

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -30,24 +30,19 @@ describe('extractMediaUrls', () => {
 });
 
 describe('collectAllMediaUrls', () => {
-  it('should collect unique URLs from all sources', () => {
+  it('should collect unique URLs from issue body and latest comment', () => {
     const issueBody = 'Issue: https://github.com/user-attachments/assets/1';
     const latestComment = 'Latest: https://github.com/user-attachments/assets/2';
-    const allComments = [
-      'Comment 1: https://github.com/user-attachments/assets/1', // duplicate from issue
-      'Comment 2: https://github.com/user-attachments/assets/3'
-    ];
 
-    const result = collectAllMediaUrls(issueBody, latestComment, allComments);
+    const result = collectAllMediaUrls(issueBody, latestComment);
     expect(result.sort()).toEqual([
       'https://github.com/user-attachments/assets/1',
-      'https://github.com/user-attachments/assets/2',
-      'https://github.com/user-attachments/assets/3'
+      'https://github.com/user-attachments/assets/2'
     ].sort());
   });
 
   it('should handle empty sources', () => {
-    const result = collectAllMediaUrls('', '', []);
+    const result = collectAllMediaUrls('', '');
     expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
This PR implements the extraction of GitHub user-attachment media URLs from the issue body and the latest comment, passing them to the Gemini CLI with the --media option.

- Modified src/index.ts to pass the issue body and latest comment to the extraction utility.
- Added collectAllMediaUrls and extractMediaUrls to src/utils/github.ts.
- Added unit tests in tests/utils/github.test.ts to verify correct extraction and deduplication.

Closes #110