### PR TITLE
Implement persona prefix for all automated comments

### DIFF
--- a/scripts/handle-validation-failure.sh
+++ b/scripts/handle-validation-failure.sh
@@ -92,7 +92,9 @@ else
 fi
 
 # 6. Post a comment on the parent issue.
-COMMENT_BODY="### ❌ Validation Failed on PR #$PR_NUMBER
+COMMENT_BODY="I am the **automation**
+
+### ❌ Validation Failed on PR #$PR_NUMBER
 
 The validation workflows failed on the associated PR. This issue has been moved back to **In Progress** for further work.
 

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -70,7 +70,7 @@ trap 'rm -f "$body_file"' EXIT
 
 if [ -n "${CONDUCTOR_PERSONA:-}" ] && [ -n "${CONDUCTOR_LAST_COMMENT_URL:-}" ]; then
   comment_id="${CONDUCTOR_LAST_COMMENT_URL##*-}"
-  echo "I am the $CONDUCTOR_PERSONA, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch $branch_name." > "$body_file"
+  echo "I am the **$CONDUCTOR_PERSONA**, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch $branch_name." > "$body_file"
   echo "" >> "$body_file"
 fi
 

--- a/scripts/move-to-human-review.sh
+++ b/scripts/move-to-human-review.sh
@@ -104,7 +104,7 @@ trap 'rm -f "$body_file"' EXIT
 if [ -n "${CONDUCTOR_PERSONA:-}" ] && [ -n "${CONDUCTOR_LAST_COMMENT_URL:-}" ]; then
   branch_name="$(git branch --show-current)"
   comment_id="${CONDUCTOR_LAST_COMMENT_URL##*-}"
-  echo "I am the $CONDUCTOR_PERSONA, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch ${branch_name:-unknown}." > "$body_file"
+  echo "I am the **$CONDUCTOR_PERSONA**, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch ${branch_name:-unknown}." > "$body_file"
   echo "" >> "$body_file"
 fi
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ function verifyGitHubCli(repository: string, issueNumber: number): string {
     logger.error(`GitHub CLI preflight failed for ${repository}.`);
     if (failureDetails) process.stderr.write(`${failureDetails}\n`);
 
-    const body = `### ❌ GitHub CLI Preflight Failed
+    const body = `I am the **automation**
+
+### ❌ GitHub CLI Preflight Failed
 
 Issue #${issueNumber} could not verify \`gh\` access to \`${repository}\` before invoking Gemini.
 
@@ -215,7 +217,9 @@ function moveToHumanReview(
   commentCount: number,
   commentLimit: number
 ): void {
-  const body = `### Comment Limit Reached
+  const body = `I am the **automation**
+
+### Comment Limit Reached
 
 Automation is aborting for this issue because the comment count exceeded the configured limit.
 
@@ -280,7 +284,9 @@ function activatePersonaLabel(repository: string, issueNumber: number, persona: 
 }
 
 function postPickupNote(repository: string, issueNumber: number, persona: string, branch: string): void {
-  const body = `The **${persona}** has picked up this task and is working on **${branch}**.`;
+  const body = `I am the **automation**
+
+The **${persona}** has picked up this task and is working on **${branch}**.`;
   
   logger.info(`Posting pickup note to issue #${issueNumber} in ${repository}...`);
   
@@ -484,7 +490,9 @@ ENVIRONMENT:
       const lines = errorOutput.split('\n');
       const snippet = lines.length > 50 ? lines.slice(-50).join('\n') : errorOutput;
 
-      const body = `### ❌ Gemini CLI Execution Failed
+      const body = `I am the **automation**
+
+### ❌ Gemini CLI Execution Failed
 
 **Exit Code**: ${result.status}
 

--- a/tests/handoff_test.sh
+++ b/tests/handoff_test.sh
@@ -599,7 +599,7 @@ chmod +x "$TEST_DIR/gh"
 echo "Running handoff.sh (checking for header)..."
 echo "Original body" | bash scripts/handoff.sh conductor
 
-if grep -q "I am the coder, and I am responding to comment \[456789\](https://github.com/LLM-Orchestration/conductor/issues/123#issuecomment-456789) on branch test-branch." "$TEST_DIR/captured_body.md"; then
+if grep -Fq "I am the **coder**, and I am responding to comment [456789](https://github.com/LLM-Orchestration/conductor/issues/123#issuecomment-456789) on branch test-branch." "$TEST_DIR/captured_body.md"; then
   echo "Success: Header prepended correctly"
 else
   echo "Error: Header NOT prepended correctly"


### PR DESCRIPTION
This PR implements the mandatory persona prefix for all automated comments as requested in #112.

### Changes:
- **src/index.ts**: Added `I am the **automation**` prefix to all automated reports (preflight, pickup, execution failures, comment limit).
- **scripts/handle-validation-failure.sh**: Added `I am the **automation**` prefix to validation failure reports.
- **scripts/handoff.sh** & **scripts/move-to-human-review.sh**: Updated persona prefix to use bold format (e.g., `I am the **coder**`).
- **tests/handoff_test.sh**: Updated tests to expect the new bolded format.

Closes #112