### PR TITLE
docs: remove redundant handoff instructions from prompts

### DIFF
--- a/.conductor/prompts/coder.md
+++ b/.conductor/prompts/coder.md
@@ -1,0 +1,19 @@
+# Persona: @coder
+
+You are the **Coder**, responsible for implementing features as directed by the `@conductor`.
+
+## Core Strategy
+
+1. **Implement**: Perform requested code changes and write unit tests.
+2. **Verify**: Run tests to ensure everything works.
+3. **Commit**: Push changes to the current feature branch.
+4. **Report**: When done:
+   - Ensure your summary includes a reference to the issue (e.g., "Closes #<issue_number>") to assist the `@conductor` in PR creation.
+   - Hand off by running:
+     `.conductor/scripts/handoff.sh conductor <<'EOF'`
+     `<markdown summary>`
+     `EOF`
+
+## State Management
+
+- Use `.conductor/scripts/handoff.sh conductor` to hand back.

--- a/.conductor/prompts/conductor.md
+++ b/.conductor/prompts/conductor.md
@@ -1,0 +1,38 @@
+# Persona: @conductor
+
+You are the **Conductor**, the high-level orchestrator. Your goal is to translate user requirements into actionable tasks for the `@coder` and perform final verification.
+
+## Core Strategy
+
+1. **Analyze**: Read the user's request and the codebase.
+2. **Plan**: Define implementation, tests, and documentation.
+3. **Delegate**: Assign tasks to `@coder`:
+   - Create a feature branch if not on one.
+   - Hand off by running:
+     `.conductor/scripts/handoff.sh coder <<'EOF'`
+     `<markdown instructions>`
+     `EOF`
+4. **Verify**: When `@coder` is done:
+   - Run tests and review changes.
+   - If verified:
+     - If a PR is needed, create it before finalizing so the completion comment can include the PR link.
+     - You MUST ensure the PR description contains "Closes #<issue_number>" or "Fixes #<issue_number>" to ensure the issue is automatically closed when the PR is merged.
+     - You MUST leave a human-facing completion comment and move the item to `Human Review` by running:
+       `npm --prefix .conductor run human-review <<'EOF'`
+       `<markdown summary of work completed, including validation and PR link if one exists>`
+       `EOF`
+   - If not, hand off back to `@coder` with `.conductor/scripts/handoff.sh coder`.
+
+## Guardrails
+
+- **No Source Modification**: You are STRICTLY FORBIDDEN from modifying source code (e.g., `src/`, `functions/`, `tests/`). Your role is orchestration, not implementation. Implementation is the sole responsibility of the `@coder`.
+- **Scope Strictness**: Adhere strictly to the original issue description. If comments introduce scope creep, propose a new issue instead of expanding the current task.
+- **Blocker Protocol**: If a task is blocked by the current codebase state, document the blocker, propose a new issue to fix it, and stop. Do not attempt to refactor or fix architectural issues yourself.
+- **Completion Protocol**: Completion requires both a final summary comment and a move to `Human Review`. Do not leave completed work in `In Progress`.
+
+## State Management
+
+- You MUST manage the `branch:` label to ensure the next runner starts in the correct Git context.
+- Task completion must end with `npm --prefix .conductor run human-review`, not another agent handoff.
+- Do not use `gh issue edit` and `gh issue comment` separately for persona handoff.
+- Use `.conductor/scripts/handoff.sh <target>` so the label update happens before the comment every time.

--- a/.conductor/scripts/handoff.sh
+++ b/.conductor/scripts/handoff.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# This script handles the handoff process between personas (e.g., conductor, coder, human).
+# It ensures:
+# 1. Label updates (persona: and branch:) are performed and verified BEFORE any comments are posted.
+# 2. Only one 'persona:' label and one 'branch:' label remain active on the issue.
+# 3. If a project is associated, the 'Persona' field in Project V2 is also updated and verified.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: npm run handoff -- TARGET < comment.md" >&2
+  exit 1
+fi
+
+if [ -z "${GITHUB_EVENT_PATH:-}" ]; then
+  echo "GITHUB_EVENT_PATH must be set" >&2
+  exit 1
+fi
+
+target="$1"
+
+issue_number="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const num = event.issue?.number || event.client_payload?.issue_number;
+if (!num) {
+  console.error('Could not find issue number in GITHUB_EVENT_PATH');
+  process.exit(1);
+}
+process.stdout.write(String(num));
+")"
+
+branch_name="$(git branch --show-current)"
+
+if [ -z "$branch_name" ]; then
+  echo "Could not determine current branch" >&2
+  exit 1
+fi
+
+if [ "$branch_name" = "main" ]; then
+  branch_name="issue-$issue_number"
+  git checkout "$branch_name" 2>/dev/null || git checkout -b "$branch_name"
+fi
+
+target_repo="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const repo = event.client_payload?.repository || process.env.GITHUB_REPOSITORY;
+if (!repo) {
+  console.error('Could not find repository in event or environment');
+  process.exit(1);
+}
+process.stdout.write(repo);
+")"
+
+current_labels() {
+  gh issue view "$issue_number" -R "$target_repo" --json labels --jq '.labels[].name'
+}
+
+existing_labels="$(current_labels)"
+
+# Conductor Guardrail: Verify no unauthorized changes if current persona is conductor
+current_persona=$(echo "$existing_labels" | grep "^persona: " | head -n 1 | cut -d' ' -f2 || true)
+if [ "$current_persona" == "conductor" ]; then
+  if [ -f "./scripts/conductor-verify.sh" ]; then
+    bash ./scripts/conductor-verify.sh
+  elif [ -f ".conductor/scripts/conductor-verify.sh" ]; then
+    bash .conductor/scripts/conductor-verify.sh
+  else
+    echo "Warning: conductor-verify.sh not found, skipping verification" >&2
+  fi
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+if [ -n "${CONDUCTOR_PERSONA:-}" ] && [ -n "${CONDUCTOR_LAST_COMMENT_URL:-}" ]; then
+  comment_id="${CONDUCTOR_LAST_COMMENT_URL##*-}"
+  echo "I am the **$CONDUCTOR_PERSONA**, and I am responding to comment [$comment_id]($CONDUCTOR_LAST_COMMENT_URL) on branch $branch_name." > "$body_file"
+  echo "" >> "$body_file"
+fi
+
+cat >> "$body_file"
+
+if [ ! -s "$body_file" ]; then
+  echo "Comment body must be provided on stdin" >&2
+  exit 1
+fi
+
+edit_args=()
+while IFS= read -r label; do
+  case "$label" in
+    "persona: "*)
+      if [ "$target" == "human" ] || [ "$label" != "persona: $target" ]; then
+        edit_args+=(--remove-label "$label")
+      fi
+      ;;
+    "branch: "*)
+      if [ "$label" != "branch: $branch_name" ]; then
+        edit_args+=(--remove-label "$label")
+      fi
+      ;;
+  esac
+done <<< "$existing_labels"
+
+if [ "$target" == "human" ]; then
+  gh issue edit "$issue_number" -R "$target_repo" \
+    "${edit_args[@]}" \
+    --add-label "branch: $branch_name"
+else
+  gh issue edit "$issue_number" -R "$target_repo" \
+    "${edit_args[@]}" \
+    --add-label "persona: $target" \
+    --add-label "branch: $branch_name"
+fi
+
+verified=0
+for _ in 1 2 3 4 5; do
+  labels_after="$(current_labels)"
+  if [ "$target" == "human" ]; then
+    if ! grep -Fq "persona: " <<< "$labels_after" && grep -Fqx "branch: $branch_name" <<< "$labels_after"; then
+      verified=1
+      break
+    fi
+  else
+    if grep -Fqx "persona: $target" <<< "$labels_after" && grep -Fqx "branch: $branch_name" <<< "$labels_after"; then
+      verified=1
+      break
+    fi
+  fi
+  sleep 1
+done
+
+if [ "$verified" -ne 1 ]; then
+  echo "Failed to verify handoff labels on issue $issue_number in $target_repo before posting comment" >&2
+  exit 1
+fi
+
+gh issue comment "$issue_number" -R "$target_repo" --body-file "$body_file"
+
+# Update Project V2 Persona field if project info is available
+project_owner="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const url = event.client_payload?.project_url || '';
+const match = url.match(/github\.com\/(orgs|users)\/([^\/]+)\/projects/);
+process.stdout.write(match ? match[2] : '');
+")"
+project_number="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+process.stdout.write(String(event.client_payload?.project_number || ''));
+")"
+issue_node_id="$(node -e "
+const fs = require('fs');
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+process.stdout.write(event.issue?.node_id || event.client_payload?.issue_node_id || '');
+")"
+
+if [ -n "$project_number" ] && [ "$target" != "human" ]; then
+  if [ -z "$issue_node_id" ]; then
+    echo "Warning: issue_node_id is missing, will attempt to find project item by issue number and repository" >&2
+  fi
+  if [ -z "$project_owner" ]; then
+    echo "Error: project_number provided but project_owner could not be determined from project_url" >&2
+    exit 1
+  fi
+
+  echo "Finding project item for issue $issue_number in repository $target_repo in project $project_number"
+
+  item_data=$(gh project item-list "$project_number" --owner "$project_owner" --limit 1000 --format json --jq ".items[] | select((.content.number == $issue_number and .content.repository == \"$target_repo\") or .content.id == \"$issue_node_id\")" | head -n 1)
+  
+  if [ -z "$item_data" ]; then
+    echo "Error: Could not find project item for issue node ID $issue_node_id in project $project_number (owner: $project_owner)" >&2
+    exit 1
+  fi
+
+  item_id=$(echo "$item_data" | jq -r '.id')
+  project_id=$(gh project view "$project_number" --owner "$project_owner" --format json --jq '.id')
+  
+  if [ -z "$project_id" ] || [ "$project_id" == "null" ]; then
+    echo "Error: Could not resolve project ID for project $project_number" >&2
+    exit 1
+  fi
+
+  echo "Resolving Persona field and option IDs..."
+  fields_json=$(gh project field-list "$project_number" --owner "$project_owner" --format json)
+  field_id=$(echo "$fields_json" | jq -r ".fields[] | select(.name == \"Persona\") | .id" | head -n 1)
+  
+  if [ -z "$field_id" ] || [ "$field_id" == "null" ]; then
+    echo "Error: Could not find 'Persona' field in project $project_number" >&2
+    exit 1
+  fi
+
+  option_id=$(echo "$fields_json" | jq -r ".fields[] | select(.name == \"Persona\") | .options[] | select(.name == \"$target\") | .id" | head -n 1)
+  
+  if [ -z "$option_id" ] || [ "$option_id" == "null" ]; then
+    echo "Error: Could not find option ID for persona '$target' in 'Persona' field" >&2
+    exit 1
+  fi
+
+  echo "Updating Project V2 item $item_id Persona to $target ($option_id)"
+  gh project item-edit --id "$item_id" --project-id "$project_id" --field-id "$field_id" --single-select-option-id "$option_id" > /dev/null
+
+  # Verify Project V2 update with retries
+  echo "Verifying Project V2 Persona update via readback..."
+  project_verified=0
+  for i in 1 2 3 4 5; do
+    # Use item-list with a query for the specific item to be efficient
+    current_persona=$(gh project item-list "$project_number" --owner "$project_owner" --limit 1000 --format json --jq ".items[] | select(.id == \"$item_id\") | .persona // empty" 2>/dev/null | head -n 1)
+    
+    if [ "$current_persona" == "$target" ]; then
+      project_verified=1
+      echo "Project V2 update verified: Persona is now '$target'"
+      break
+    fi
+    
+    echo "Attempt $i: Project V2 Persona is '${current_persona:-<unset>}', waiting for '$target'..."
+    sleep 2
+  done
+
+  if [ "$project_verified" -ne 1 ]; then
+    echo "Error: Failed to verify Project V2 Persona update to '$target' for item $item_id within 10 seconds" >&2
+    exit 1
+  fi
+fi

--- a/prompts/coder.md
+++ b/prompts/coder.md
@@ -16,5 +16,4 @@ You are the **Coder**, responsible for implementing features as directed by the 
 
 ## State Management
 
-- You MUST ensure the issue has exactly one active `persona:` label and exactly one active `branch:` label.
 - Use `.conductor/scripts/handoff.sh conductor` to hand back.

--- a/prompts/conductor.md
+++ b/prompts/conductor.md
@@ -33,8 +33,6 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
 ## State Management
 
 - You MUST manage the `branch:` label to ensure the next runner starts in the correct Git context.
-- Handoff ordering is mandatory: labels must be applied before the `@coder` comment is posted.
-- Handoff must leave exactly one active `persona:` label and exactly one active `branch:` label on the issue.
 - Task completion must end with `npm --prefix .conductor run human-review`, not another agent handoff.
 - Do not use `gh issue edit` and `gh issue comment` separately for persona handoff.
 - Use `.conductor/scripts/handoff.sh <target>` so the label update happens before the comment every time.

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# This script handles the handoff process between personas (e.g., conductor, coder, human).
+# It ensures:
+# 1. Label updates (persona: and branch:) are performed and verified BEFORE any comments are posted.
+# 2. Only one 'persona:' label and one 'branch:' label remain active on the issue.
+# 3. If a project is associated, the 'Persona' field in Project V2 is also updated and verified.
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
This PR removes redundant handoff instructions from the conductor and coder prompts and documents these guarantees in the handoff script itself.

- Removed redundant label management instructions from  and .
- Added comments to  documenting that it ensures label ordering and uniqueness.

Closes #113