### PR TITLE
feat: implement Sibling Workspace strategy to isolate conductor framework

### DIFF
--- a/.github/workflows/conductor.yml
+++ b/.github/workflows/conductor.yml
@@ -32,7 +32,7 @@ jobs:
           repository: ${{ steps.metadata.outputs.repository }}
           fetch-depth: 0
           token: ${{ secrets.CONDUCTOR_TOKEN }}
-          path: '.'
+          path: 'target'
 
       - name: Checkout Conductor Repo
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
           repository: LLM-Orchestration/conductor
           fetch-depth: 0
           token: ${{ secrets.CONDUCTOR_TOKEN }}
-          path: '.conductor'
+          path: 'conductor'
 
       - name: Determine Branch
         id: branch
@@ -57,6 +57,7 @@ jobs:
           echo "Selected branch: $BRANCH"
 
       - name: Switch Target Repo to Branch
+        working-directory: target
         run: |
           BRANCH=${{ steps.branch.outputs.branch }}
           git checkout "$BRANCH" || git checkout -b "$BRANCH"
@@ -66,29 +67,31 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: .conductor/package-lock.json
+          cache-dependency-path: conductor/package-lock.json
 
       - name: Install Dependencies
-        working-directory: .conductor
+        working-directory: conductor
         run: npm install
 
       - name: Build
-        working-directory: .conductor
+        working-directory: conductor
         run: npm run build
 
       - name: Prepare Gemini Auth
-        working-directory: .conductor
+        working-directory: conductor
         env:
           GEMINI_API_KEY_SECRET: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_OAUTH_CREDS_JSON: ${{ secrets.GEMINI_OAUTH_CREDS_JSON }}
         run: npm run gemini:prepare-auth
 
       - name: Run Conductor
-        working-directory: .conductor
+        working-directory: conductor
         env:
           CONDUCTOR_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
           GH_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.CONDUCTOR_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_REPOSITORY: ${{ steps.metadata.outputs.repository }}
+          CONDUCTOR_ROOT: ${{ github.workspace }}/conductor
+          CONDUCTOR_TARGET_DIR: ${{ github.workspace }}/target
         run: npm start

--- a/PROJECTS_V2_INTEGRATION.md
+++ b/PROJECTS_V2_INTEGRATION.md
@@ -201,16 +201,20 @@ The Conductor is designed to be a central orchestrator for an entire organizatio
 
 1.  **Trigger**: An event occurs in any repository (e.g., an issue is moved to "In Progress" in an org-level project, or `@conductor` is mentioned in an issue comment).
 2.  **Bridge**: The Firebase Bridge function receives the org-level webhook and dispatches a `repository_dispatch` event to the central `LLM-Orchestration/conductor` repository.
-3.  **Workflow**: The Conductor workflow starts and:
+3. **Workflow**: The Conductor workflow starts and:
     *   Determines the target repository and issue number from the payload.
-    *   Performs a **Dual Checkout**:
-        *   Target Repo is checked out to `.` (the root).
-        *   Conductor Repo is checked out to `.conductor/`.
-    *   The Conductor logic runs from `.conductor/` but executes the Gemini CLI with the working directory set to the root (`.`), where the target repo resides.
-4.  **Handoff**: The agents use the handoff script located at `.conductor/scripts/handoff.sh`, which explicitly targets the target repository using the `-R` flag.
+    *   Performs a **Sibling Workspace Checkout**:
+        *   Target Repo is checked out to `target/`.
+        *   Conductor Repo is checked out to `conductor/`.
+    *   The Conductor logic runs from `conductor/` but executes the Gemini CLI with the working directory set to `target/`.
+    *   Environment variables `CONDUCTOR_ROOT` and `CONDUCTOR_TARGET_DIR` are set to provide explicit paths.
+4. **Handoff**: The agents use the handoff script located at `${CONDUCTOR_ROOT}/scripts/handoff.sh`, which explicitly targets the target repository using the `-R` flag.
 
 ### Deployment Notes
 
 *   **GitHub Token**: The `CONDUCTOR_TOKEN` secret in the central repository must have `write` access to all repositories it is expected to orchestrate.
 *   **Webhook**: The GitHub App or Webhook must be configured at the **Organization** level to receive events from all repositories.
 *   **Standard Labels**: All repositories should use the same `persona:` and `branch:` label conventions for seamless orchestration.
+*   **Environment Variables**: The following variables are used for path resolution:
+    *   `CONDUCTOR_ROOT`: Absolute path to the conductor repository.
+    *   `CONDUCTOR_TARGET_DIR`: Absolute path to the target repository.

--- a/prompts/coder.md
+++ b/prompts/coder.md
@@ -10,10 +10,10 @@ You are the **Coder**, responsible for implementing features as directed by the 
 4. **Report**: When done:
    - Ensure your summary includes a reference to the issue (e.g., "Closes #<issue_number>") to assist the `@conductor` in PR creation.
    - Hand off by running:
-     `.conductor/scripts/handoff.sh conductor <<'EOF'`
+     `${CONDUCTOR_ROOT}/scripts/handoff.sh conductor <<'EOF'`
      `<markdown summary>`
      `EOF`
 
 ## State Management
 
-- Use `.conductor/scripts/handoff.sh conductor` to hand back.
+- Use `${CONDUCTOR_ROOT}/scripts/handoff.sh conductor` to hand back.

--- a/prompts/conductor.md
+++ b/prompts/conductor.md
@@ -9,7 +9,7 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
 3. **Delegate**: Assign tasks to `@coder`:
    - Create a feature branch if not on one.
    - Hand off by running:
-     `.conductor/scripts/handoff.sh coder <<'EOF'`
+     `${CONDUCTOR_ROOT}/scripts/handoff.sh coder <<'EOF'`
      `<markdown instructions>`
      `EOF`
 4. **Verify**: When `@coder` is done:
@@ -18,10 +18,10 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
      - If a PR is needed, create it before finalizing so the completion comment can include the PR link.
      - You MUST ensure the PR description contains "Closes #<issue_number>" or "Fixes #<issue_number>" to ensure the issue is automatically closed when the PR is merged.
      - You MUST leave a human-facing completion comment and move the item to `Human Review` by running:
-       `npm --prefix .conductor run human-review <<'EOF'`
+       `npm --prefix ${CONDUCTOR_ROOT} run human-review <<'EOF'`
        `<markdown summary of work completed, including validation and PR link if one exists>`
        `EOF`
-   - If not, hand off back to `@coder` with `.conductor/scripts/handoff.sh coder`.
+   - If not, hand off back to `@coder` with `${CONDUCTOR_ROOT}/scripts/handoff.sh coder`.
 
 ## Guardrails
 
@@ -33,6 +33,6 @@ You are the **Conductor**, the high-level orchestrator. Your goal is to translat
 ## State Management
 
 - You MUST manage the `branch:` label to ensure the next runner starts in the correct Git context.
-- Task completion must end with `npm --prefix .conductor run human-review`, not another agent handoff.
+- Task completion must end with `npm --prefix ${CONDUCTOR_ROOT} run human-review`, not another agent handoff.
 - Do not use `gh issue edit` and `gh issue comment` separately for persona handoff.
-- Use `.conductor/scripts/handoff.sh <target>` so the label update happens before the comment every time.
+- Use `${CONDUCTOR_ROOT}/scripts/handoff.sh <target>` so the label update happens before the comment every time.

--- a/scripts/conductor-verify.sh
+++ b/scripts/conductor-verify.sh
@@ -8,6 +8,12 @@ forbidden_dirs=("src" "functions" "tests")
 
 echo "Running conductor verification..."
 
+# If CONDUCTOR_TARGET_DIR is set, we need to check THAT directory, not the current one.
+if [ -n "${CONDUCTOR_TARGET_DIR:-}" ]; then
+  cd "$CONDUCTOR_TARGET_DIR"
+  echo "Checking target directory: $CONDUCTOR_TARGET_DIR"
+fi
+
 # Check for uncommitted changes (including untracked files) in forbidden directories
 # We use 'git status --porcelain' to catch both modified and untracked files.
 uncommitted_changes=$(git status --porcelain -- "${forbidden_dirs[@]}" | awk '{print $2}')

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -68,8 +68,6 @@ if [ "$current_persona" == "conductor" ]; then
     # Fallback for local dev or transition
     if [ -f "./scripts/conductor-verify.sh" ]; then
       bash ./scripts/conductor-verify.sh
-    elif [ -f ".conductor/scripts/conductor-verify.sh" ]; then
-      bash .conductor/scripts/conductor-verify.sh
     else
       echo "Warning: conductor-verify.sh not found, skipping verification" >&2
     fi

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -61,12 +61,18 @@ existing_labels="$(current_labels)"
 # Conductor Guardrail: Verify no unauthorized changes if current persona is conductor
 current_persona=$(echo "$existing_labels" | grep "^persona: " | head -n 1 | cut -d' ' -f2 || true)
 if [ "$current_persona" == "conductor" ]; then
-  if [ -f "./scripts/conductor-verify.sh" ]; then
-    bash ./scripts/conductor-verify.sh
-  elif [ -f ".conductor/scripts/conductor-verify.sh" ]; then
-    bash .conductor/scripts/conductor-verify.sh
+  verify_script="${CONDUCTOR_ROOT:-.}/scripts/conductor-verify.sh"
+  if [ -f "$verify_script" ]; then
+    bash "$verify_script"
   else
-    echo "Warning: conductor-verify.sh not found, skipping verification" >&2
+    # Fallback for local dev or transition
+    if [ -f "./scripts/conductor-verify.sh" ]; then
+      bash ./scripts/conductor-verify.sh
+    elif [ -f ".conductor/scripts/conductor-verify.sh" ]; then
+      bash .conductor/scripts/conductor-verify.sh
+    else
+      echo "Warning: conductor-verify.sh not found, skipping verification" >&2
+    fi
   fi
 fi
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -417,9 +417,10 @@ async function main() {
     postPickupNote(repository, issueNumber, persona, currentBranch);
 
     // 3. Load Prompt
-    const promptPath = path.join(__dirname, '..', 'prompts', `${persona}.md`);
+    const conductorRoot = process.env.CONDUCTOR_ROOT || path.join(__dirname, '..', '..');
+    const promptPath = path.join(conductorRoot, 'prompts', `${persona}.md`);
     if (!fs.existsSync(promptPath)) {
-      logger.error(`Prompt not found for persona: ${persona}`);
+      logger.error(`Prompt not found at ${promptPath} for persona: ${persona}`);
       process.exit(1);
     }
     const systemPrompt = fs.readFileSync(promptPath, 'utf8');
@@ -477,10 +478,12 @@ ENVIRONMENT:
     const childEnv = buildGeminiEnv();
     childEnv.CONDUCTOR_PERSONA = persona;
     childEnv.CONDUCTOR_LAST_COMMENT_URL = lastCommentUrl;
+    childEnv.CONDUCTOR_ROOT = conductorRoot;
     
-    // The target repository is at the root (../ from .conductor/dist/src or ../ from .conductor if running via npm start)
-    // In Actions, GITHUB_WORKSPACE is the root.
-    const targetCwd = process.env.GITHUB_WORKSPACE || path.resolve(process.cwd(), '..');
+    // The target repository directory
+    const targetCwd = process.env.CONDUCTOR_TARGET_DIR || process.env.GITHUB_WORKSPACE || path.resolve(process.cwd(), '..');
+    childEnv.CONDUCTOR_TARGET_DIR = targetCwd;
+
     const result = await runStreamingCommand('npx', args, childEnv, targetCwd);
 
     if (result.status !== 0) {


### PR DESCRIPTION
This PR implements the Sibling Workspace strategy to prevent the conductor framework code from being checked out inside the target repository's worktree. This avoids confusing LLMs working on the target repository.

### Key Changes:
- **Dual Checkout -> Sibling Checkout**: Updated `.github/workflows/conductor.yml` to checkout the target repo to `target/` and the conductor repo to `conductor/`.
- **Environment Variables**: Introduced `CONDUCTOR_ROOT` and `CONDUCTOR_TARGET_DIR` for explicit path resolution.
- **Framework Isolation**: Updated `src/index.ts` to use these variables, ensuring the Gemini CLI starts in the correct directory without seeing the framework code.
- **Dynamic Paths**: Updated prompts and scripts (`handoff.sh`, `conductor-verify.sh`, etc.) to use ${CONDUCTOR_ROOT} instead of hardcoded `.conductor` paths.
- **Cleanup**: Removed legacy `.conductor` fallback logic from scripts.

Closes #117