### PR TITLE
feat: intercept MESSAGE_BUS debug messages and turn them into UI events

### DIFF
--- a/observability-ui/src/lib/components/GeminiEvent.svelte
+++ b/observability-ui/src/lib/components/GeminiEvent.svelte
@@ -6,9 +6,12 @@
   const eventData = $derived(event.data as GeminiEventData);
 
   const getEventClass = (data: GeminiEventData) => {
-    const base = `gemini-event ${data.type.replace(/_/g, '-')}`;
+    let base = `gemini-event ${data.type.replace(/_/g, '-')}`;
     if (data.type === 'message') {
-      return `${base} ${data.role}`;
+      base += ` ${data.role}`;
+    }
+    if (data._isMessageBus) {
+      base += ' is-message-bus';
     }
     return base;
   };
@@ -38,46 +41,60 @@
 </script>
 
 <div class={getEventClass(eventData)}>
-  {#if eventData.type === 'init'}
-    <div class="event-header">
-      <span class="icon">🤖</span>
-      <span class="event-type">Gemini Initialized</span>
+  {#if eventData._isMessageBus}
+    <div class="event-header message-bus-header">
+      <span class="icon">🚌</span>
+      <span class="event-type">DEBUG MESSAGE_BUS: {eventData.type.toUpperCase().replace(/-/g, ' ')}</span>
     </div>
+  {/if}
+  {#if eventData.type === 'init'}
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">🤖</span>
+        <span class="event-type">Gemini Initialized</span>
+      </div>
+    {/if}
     <div class="event-body">
       <p><strong>Session ID:</strong> <code>{eventData.sessionId}</code></p>
       <p><strong>Model:</strong> <code>{eventData.model}</code></p>
     </div>
   {:else if eventData.type === 'message'}
-    <div class="event-header">
-      <span class="icon">{eventData.role === 'assistant' ? '✨' : '👤'}</span>
-      <span class="event-type">{eventData.role}</span>
-    </div>
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">{eventData.role === 'assistant' ? '✨' : '👤'}</span>
+        <span class="event-type">{eventData.role}</span>
+      </div>
+    {/if}
     <div class="event-body">
       <p>{eventData.content}</p>
     </div>
   {:else if eventData.type === 'tool_use'}
-    <div class="event-header">
-      <span class="icon">🛠️</span>
-      <span class="event-type">Tool Use: {getToolName(eventData)}</span>
-      {#if eventData.tool_id}
-        <span class="tool-id">({eventData.tool_id})</span>
-      {/if}
-    </div>
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">🛠️</span>
+        <span class="event-type">Tool Use: {getToolName(eventData)}</span>
+        {#if eventData.tool_id}
+          <span class="tool-id">({eventData.tool_id})</span>
+        {/if}
+      </div>
+    {/if}
     <div class="event-body">
       <pre><code>{JSON.stringify(getToolArgs(eventData), null, 2)}</code></pre>
     </div>
   {:else if eventData.type === 'tool_result'}
-    <div class="event-header">
-      <span class="icon">📤</span>
-      <span class="event-type">TOOL RESULT: {getToolName(eventData)}
-        {#if eventData.status || (eventData.data && eventData.data.status)}
-          ({eventData.status || eventData.data.status})
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">📤</span>
+        <span class="event-type">TOOL RESULT: {getToolName(eventData)}
+          {#if eventData.status || (eventData.data && eventData.data.status)}
+            ({eventData.status || eventData.data.status})
+          {/if}
+        </span>
+        {#if eventData.tool_id}
+          <span class="tool-id">({eventData.tool_id})</span>
         {/if}
-      </span>
-      {#if eventData.tool_id}
-        <span class="tool-id">({eventData.tool_id})</span>
-      {/if}
-    </div>
+      </div>
+    {/if}
     <div class="event-body">
       {#if eventData.status || eventData.output || (eventData.data && (eventData.data.status || eventData.data.output))}
         {@const status = eventData.status || (eventData.data && eventData.data.status)}
@@ -97,10 +114,12 @@
       {/if}
     </div>
   {:else if eventData.type === 'tool-calls-update'}
-    <div class="event-header">
-      <span class="icon">📡</span>
-      <span class="event-type">Tool Calls Update: {eventData.schedulerId}</span>
-    </div>
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">📡</span>
+        <span class="event-type">Tool Calls Update: {eventData.schedulerId}</span>
+      </div>
+    {/if}
     <div class="event-body">
       {#if eventData.toolCalls && eventData.toolCalls.length > 0}
         <ul>
@@ -113,10 +132,12 @@
       {/if}
     </div>
   {:else if eventData.type === 'result'}
-    <div class="event-header">
-      <span class="icon">🏁</span>
-      <span class="event-type">Gemini Result</span>
-    </div>
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">🏁</span>
+        <span class="event-type">Gemini Result</span>
+      </div>
+    {/if}
     <div class="event-body">
       <p>{eventData.response}</p>
       {#if eventData.stats}
@@ -140,10 +161,12 @@
       {/if}
     </div>
   {:else}
-    <div class="event-header">
-      <span class="icon">❓</span>
-      <span class="event-type">Unknown Event: {eventData.type}</span>
-    </div>
+    {#if !eventData._isMessageBus}
+      <div class="event-header">
+        <span class="icon">❓</span>
+        <span class="event-type">Unknown Event: {eventData.type}</span>
+      </div>
+    {/if}
     <div class="event-body">
       <pre><code>{JSON.stringify(eventData, null, 2)}</code></pre>
     </div>
@@ -164,6 +187,12 @@
     border-left: 4px solid #6c757d;
   }
 
+  .is-message-bus {
+    border-left-color: #fd7e14;
+    background-color: #fffaf5;
+    border-style: dashed;
+  }
+
   .event-header {
     display: flex;
     gap: 0.5rem;
@@ -171,6 +200,10 @@
     margin-bottom: 0.5rem;
     border-bottom: 1px solid #eee;
     padding-bottom: 0.25rem;
+  }
+
+  .message-bus-header {
+    border-bottom-color: #ffe8cc;
   }
 
   .event-type {

--- a/observability-ui/src/lib/components/GeminiEvent.svelte
+++ b/observability-ui/src/lib/components/GeminiEvent.svelte
@@ -96,6 +96,22 @@
             : JSON.stringify(eventData.result || eventData.data || eventData, null, 2)}</code></pre>
       {/if}
     </div>
+  {:else if eventData.type === 'tool-calls-update'}
+    <div class="event-header">
+      <span class="icon">📡</span>
+      <span class="event-type">Tool Calls Update: {eventData.schedulerId}</span>
+    </div>
+    <div class="event-body">
+      {#if eventData.toolCalls && eventData.toolCalls.length > 0}
+        <ul>
+          {#each eventData.toolCalls as toolCall}
+            <li><code>{toolCall.function?.name || toolCall.id}</code></li>
+          {/each}
+        </ul>
+      {:else}
+        <p>No active tool calls</p>
+      {/if}
+    </div>
   {:else if eventData.type === 'result'}
     <div class="event-header">
       <span class="icon">🏁</span>
@@ -206,6 +222,9 @@
   }
   .tool-result {
     border-left-color: #28a745;
+  }
+  .tool-calls-update {
+    border-left-color: #17a2b8;
   }
 
   .tool-result-status {

--- a/observability-ui/src/lib/components/GeminiEvent.svelte
+++ b/observability-ui/src/lib/components/GeminiEvent.svelte
@@ -41,60 +41,58 @@
 </script>
 
 <div class={getEventClass(eventData)}>
-  {#if eventData._isMessageBus}
-    <div class="event-header message-bus-header">
-      <span class="icon">🚌</span>
-      <span class="event-type">DEBUG MESSAGE_BUS: {eventData.type.toUpperCase().replace(/-/g, ' ')}</span>
-    </div>
-  {/if}
   {#if eventData.type === 'init'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">🤖</span>
-        <span class="event-type">Gemini Initialized</span>
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">🤖</span>
+      <span class="event-type">Gemini Initialized</span>
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       <p><strong>Session ID:</strong> <code>{eventData.sessionId}</code></p>
       <p><strong>Model:</strong> <code>{eventData.model}</code></p>
     </div>
   {:else if eventData.type === 'message'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">{eventData.role === 'assistant' ? '✨' : '👤'}</span>
-        <span class="event-type">{eventData.role}</span>
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">{eventData.role === 'assistant' ? '✨' : '👤'}</span>
+      <span class="event-type">{eventData.role}</span>
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       <p>{eventData.content}</p>
     </div>
   {:else if eventData.type === 'tool_use'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">🛠️</span>
-        <span class="event-type">Tool Use: {getToolName(eventData)}</span>
-        {#if eventData.tool_id}
-          <span class="tool-id">({eventData.tool_id})</span>
-        {/if}
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">🛠️</span>
+      <span class="event-type">Tool Use: {getToolName(eventData)}</span>
+      {#if eventData.tool_id}
+        <span class="tool-id">({eventData.tool_id})</span>
+      {/if}
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       <pre><code>{JSON.stringify(getToolArgs(eventData), null, 2)}</code></pre>
     </div>
   {:else if eventData.type === 'tool_result'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">📤</span>
-        <span class="event-type">TOOL RESULT: {getToolName(eventData)}
-          {#if eventData.status || (eventData.data && eventData.data.status)}
-            ({eventData.status || eventData.data.status})
-          {/if}
-        </span>
-        {#if eventData.tool_id}
-          <span class="tool-id">({eventData.tool_id})</span>
+    <div class="event-header">
+      <span class="icon">📤</span>
+      <span class="event-type">TOOL RESULT: {getToolName(eventData)}
+        {#if eventData.status || (eventData.data && eventData.data.status)}
+          ({eventData.status || eventData.data.status})
         {/if}
-      </div>
-    {/if}
+      </span>
+      {#if eventData.tool_id}
+        <span class="tool-id">({eventData.tool_id})</span>
+      {/if}
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       {#if eventData.status || eventData.output || (eventData.data && (eventData.data.status || eventData.data.output))}
         {@const status = eventData.status || (eventData.data && eventData.data.status)}
@@ -114,12 +112,13 @@
       {/if}
     </div>
   {:else if eventData.type === 'tool-calls-update'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">📡</span>
-        <span class="event-type">Tool Calls Update: {eventData.schedulerId}</span>
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">📡</span>
+      <span class="event-type">Tool Calls Update: {eventData.schedulerId}</span>
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       {#if eventData.toolCalls && eventData.toolCalls.length > 0}
         <ul>
@@ -132,12 +131,13 @@
       {/if}
     </div>
   {:else if eventData.type === 'result'}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">🏁</span>
-        <span class="event-type">Gemini Result</span>
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">🏁</span>
+      <span class="event-type">Gemini Result</span>
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       <p>{eventData.response}</p>
       {#if eventData.stats}
@@ -161,12 +161,13 @@
       {/if}
     </div>
   {:else}
-    {#if !eventData._isMessageBus}
-      <div class="event-header">
-        <span class="icon">❓</span>
-        <span class="event-type">Unknown Event: {eventData.type}</span>
-      </div>
-    {/if}
+    <div class="event-header">
+      <span class="icon">❓</span>
+      <span class="event-type">Unknown Event: {eventData.type}</span>
+      {#if eventData._isMessageBus}
+        <span class="message-bus-badge">🚌 DEBUG</span>
+      {/if}
+    </div>
     <div class="event-body">
       <pre><code>{JSON.stringify(eventData, null, 2)}</code></pre>
     </div>
@@ -202,8 +203,14 @@
     padding-bottom: 0.25rem;
   }
 
-  .message-bus-header {
-    border-bottom-color: #ffe8cc;
+  .message-bus-badge {
+    font-size: 0.7rem;
+    background: #fd7e14;
+    color: white;
+    padding: 1px 4px;
+    border-radius: 3px;
+    margin-left: 0.5rem;
+    vertical-align: middle;
   }
 
   .event-type {

--- a/observability-ui/src/lib/components/GeminiEvent.svelte
+++ b/observability-ui/src/lib/components/GeminiEvent.svelte
@@ -121,13 +121,15 @@
     </div>
     <div class="event-body">
       {#if eventData.toolCalls && eventData.toolCalls.length > 0}
-        <ul>
+        <div class="active-tool-calls">
           {#each eventData.toolCalls as toolCall}
-            <li><code>{toolCall.function?.name || toolCall.id}</code></li>
+            <span class="tool-call-pill">
+              <code>{toolCall.function?.name || toolCall.id}</code>
+            </span>
           {/each}
-        </ul>
+        </div>
       {:else}
-        <p>No active tool calls</p>
+        <p class="no-tool-calls">No active tool calls</p>
       {/if}
     </div>
   {:else if eventData.type === 'result'}
@@ -192,6 +194,29 @@
     border-left-color: #fd7e14;
     background-color: #fffaf5;
     border-style: dashed;
+    opacity: 0.9;
+  }
+
+  .active-tool-calls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .tool-call-pill {
+    background: #e9ecef;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    border: 1px solid #dee2e6;
+  }
+
+  .no-tool-calls {
+    color: #6c757d;
+    font-style: italic;
+    font-size: 0.9rem;
+    margin: 0 !important;
   }
 
   .event-header {

--- a/observability-ui/src/lib/types.ts
+++ b/observability-ui/src/lib/types.ts
@@ -64,14 +64,19 @@ export interface GeminiToolCallsUpdateEvent {
 	schedulerId: string;
 }
 
-export type GeminiEventData =
+export interface MessageBusMixin {
+	_isMessageBus?: boolean;
+}
+
+export type GeminiEventData = (
 	| GeminiInitEvent
 	| GeminiMessageEvent
 	| GeminiToolUseEvent
 	| GeminiToolResultEvent
 	| GeminiResultEvent
 	| GeminiToolCallsUpdateEvent
-	| GeminiUnknownEvent;
+	| GeminiUnknownEvent
+) & MessageBusMixin;
 
 export interface WorkflowRun {
 	id: number;

--- a/observability-ui/src/lib/types.ts
+++ b/observability-ui/src/lib/types.ts
@@ -58,12 +58,19 @@ export interface GeminiResultEvent {
 	};
 }
 
+export interface GeminiToolCallsUpdateEvent {
+	type: 'tool-calls-update';
+	toolCalls: any[];
+	schedulerId: string;
+}
+
 export type GeminiEventData =
 	| GeminiInitEvent
 	| GeminiMessageEvent
 	| GeminiToolUseEvent
 	| GeminiToolResultEvent
 	| GeminiResultEvent
+	| GeminiToolCallsUpdateEvent
 	| GeminiUnknownEvent;
 
 export interface WorkflowRun {

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -67,21 +67,20 @@ export async function runStreamingCommand(command: string, args: string[], env: 
     const stderrForwarder = createLineForwarder('stderr', (formatted, raw) => {
       stderr += raw;
 
-      const trimmed = raw.trim();
+      const ANSI_REGEX = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+      const cleanRaw = raw.replace(ANSI_REGEX, '');
+      const trimmed = cleanRaw.trim();
 
       // Intercept MESSAGE_BUS debug messages
-      if (trimmed.includes('[MESSAGE_BUS] publish:')) {
-        const prefix = '[MESSAGE_BUS] publish:';
-        const index = trimmed.indexOf(prefix);
-        if (index !== -1) {
-          const jsonStr = trimmed.slice(index + prefix.length).trim();
-          try {
-            const parsed = JSON.parse(jsonStr);
-            logEvent('GEMINI_EVENT', parsed);
-            return;
-          } catch (e) {
-            // Not valid JSON, fallback
-          }
+      const messageBusMatch = trimmed.match(/\[MESSAGE_BUS\] publish:\s*(\{.*\})/);
+      if (messageBusMatch) {
+        try {
+          const parsed = JSON.parse(messageBusMatch[1]);
+          parsed._isMessageBus = true;
+          logEvent('GEMINI_EVENT', parsed);
+          return;
+        } catch (e) {
+          // Not valid JSON, fallback
         }
       }
 

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -68,6 +68,23 @@ export async function runStreamingCommand(command: string, args: string[], env: 
       stderr += raw;
 
       const trimmed = raw.trim();
+
+      // Intercept MESSAGE_BUS debug messages
+      if (trimmed.includes('[MESSAGE_BUS] publish:')) {
+        const prefix = '[MESSAGE_BUS] publish:';
+        const index = trimmed.indexOf(prefix);
+        if (index !== -1) {
+          const jsonStr = trimmed.slice(index + prefix.length).trim();
+          try {
+            const parsed = JSON.parse(jsonStr);
+            logEvent('GEMINI_EVENT', parsed);
+            return;
+          } catch (e) {
+            // Not valid JSON, fallback
+          }
+        }
+      }
+
       // Intercept debug logs from Gemini CLI
       if (trimmed.includes('[Routing]') || trimmed.includes('[Memory]') || trimmed.includes('[Status]')) {
         logEvent('LOG_DEBUG', { message: trimmed });

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -67,22 +67,26 @@ export async function runStreamingCommand(command: string, args: string[], env: 
     const stderrForwarder = createLineForwarder('stderr', (formatted, raw) => {
       stderr += raw;
 
+      // Robust JSON extraction from any line (including those with prefixes or ANSI codes)
+      const jsonMatch = raw.match(/(\{.*\})/);
+      if (jsonMatch) {
+        try {
+          const parsed = JSON.parse(jsonMatch[1]);
+          if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+            if (raw.includes('[MESSAGE_BUS]')) {
+              parsed._isMessageBus = true;
+            }
+            logEvent('GEMINI_EVENT', parsed);
+            return;
+          }
+        } catch (e) {
+          // Not valid JSON or missing type, fallback
+        }
+      }
+
       const ANSI_REGEX = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
       const cleanRaw = raw.replace(ANSI_REGEX, '');
       const trimmed = cleanRaw.trim();
-
-      // Intercept MESSAGE_BUS debug messages
-      const messageBusMatch = trimmed.match(/\[MESSAGE_BUS\] publish:\s*(\{.*\})/);
-      if (messageBusMatch) {
-        try {
-          const parsed = JSON.parse(messageBusMatch[1]);
-          parsed._isMessageBus = true;
-          logEvent('GEMINI_EVENT', parsed);
-          return;
-        } catch (e) {
-          // Not valid JSON, fallback
-        }
-      }
 
       // Intercept debug logs from Gemini CLI
       if (trimmed.includes('[Routing]') || trimmed.includes('[Memory]') || trimmed.includes('[Status]')) {

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -24,6 +24,22 @@ export function parseLogs(logs: string): ConductorEvent[] {
         // Only log error if it looks like it SHOULD have been a complete JSON
         console.error('Failed to parse conductor event:', jsonStr, e);
       }
+    } else if (line.includes('[MESSAGE_BUS] publish:')) {
+      const match = line.match(/\[MESSAGE_BUS\] publish:\s*(\{.*\})/);
+      if (match) {
+        try {
+          const data = JSON.parse(match[1]);
+          data._isMessageBus = true;
+          events.push({
+            v: 1,
+            ts: new Date().toISOString(), // We don't have a timestamp in the raw log line usually, or it's outside
+            event: 'GEMINI_EVENT',
+            data
+          });
+        } catch (e) {
+          console.error('Failed to parse message bus event:', match[1], e);
+        }
+      }
     }
   }
 

--- a/tests/e2e/007-json-mode/008-message-bus.spec.ts
+++ b/tests/e2e/007-json-mode/008-message-bus.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { TestStepHelper } from '../helpers/test-step-helper';
+
+test('Gemini Message Bus Events', async ({ page }, testInfo) => {
+  const helper = new TestStepHelper(page, testInfo);
+  helper.setMetadata('Gemini Message Bus Events', 'Verify that Message Bus events are correctly rendered as debug cards.');
+
+  await page.goto('/debug');
+
+  const sampleLogs = [
+    '::CONDUCTOR_EVENT::{"v":1,"ts":"2026-04-17T12:00:00.000Z","event":"GEMINI_EVENT","data":{"type":"tool-calls-update","toolCalls":[],"schedulerId":"root","_isMessageBus":true}}',
+    '[stderr] [MESSAGE_BUS] publish: {"type":"tool-calls-update","toolCalls":[{"id":"call_1","function":{"name":"read_file"}}],"schedulerId":"root"}',
+  ].join('\n');
+
+  await page.fill('textarea', sampleLogs);
+
+  await helper.step('message_bus_events_rendered', {
+    description: 'User pastes Message Bus events',
+    verifications: [
+      {
+        spec: 'Both events are rendered as cards',
+        check: async () => {
+          await expect(page.getByText('Tool Calls Update: root')).toHaveCount(2);
+          await expect(page.getByText('🚌 DEBUG')).toHaveCount(2);
+        }
+      },
+      {
+        spec: 'Empty tool calls shows status',
+        check: async () => {
+          await expect(page.getByText('No active tool calls')).toBeVisible();
+        }
+      },
+      {
+        spec: 'Active tool call shows function name',
+        check: async () => {
+          await expect(page.getByText('read_file')).toBeVisible();
+        }
+      }
+    ]
+  });
+
+  helper.generateDocs();
+});

--- a/tests/utils/exec.test.ts
+++ b/tests/utils/exec.test.ts
@@ -96,5 +96,18 @@ describe('exec utility', () => {
       });
       expect(logEventSpy).not.toHaveBeenCalledWith('STDERR', expect.anything());
     });
+
+    it('should intercept any JSON event in stderr with a type field', async () => {
+      const logEventSpy = vi.spyOn(loggerModule, 'logEvent');
+      const msg = 'SOME_PREFIX {"type":"generic-event","foo":"bar"}';
+      const result = await runStreamingCommand('sh', ['-c', `echo '${msg}' >&2`], process.env);
+      
+      expect(result.status).toBe(0);
+      expect(logEventSpy).toHaveBeenCalledWith('GEMINI_EVENT', {
+        type: 'generic-event',
+        foo: 'bar'
+      });
+      expect(logEventSpy).not.toHaveBeenCalledWith('STDERR', expect.anything());
+    });
   });
 });

--- a/tests/utils/exec.test.ts
+++ b/tests/utils/exec.test.ts
@@ -67,7 +67,7 @@ describe('exec utility', () => {
       expect(fs.realpathSync(result.stdout.trim())).toBe(fs.realpathSync('/tmp'));
     });
 
-    it('should intercept MESSAGE_BUS messages in stderr', async () => {
+    it('should intercept MESSAGE_BUS messages in stderr and add _isMessageBus flag', async () => {
       const logEventSpy = vi.spyOn(loggerModule, 'logEvent');
       const msg = '[MESSAGE_BUS] publish: {"type":"tool-calls-update","toolCalls":[],"schedulerId":"root"}';
       const result = await runStreamingCommand('sh', ['-c', `echo '${msg}' >&2`], process.env);
@@ -76,10 +76,25 @@ describe('exec utility', () => {
       expect(logEventSpy).toHaveBeenCalledWith('GEMINI_EVENT', {
         type: 'tool-calls-update',
         toolCalls: [],
-        schedulerId: 'root'
+        schedulerId: 'root',
+        _isMessageBus: true
       });
-      // Should still be in the result.stderr buffer
-      expect(result.stderr).toContain(msg);
+      // It should NOT have been logged to stderr (terminal log)
+      expect(logEventSpy).not.toHaveBeenCalledWith('STDERR', expect.anything());
+    });
+
+    it('should handle MESSAGE_BUS messages with ANSI colors and prefixes', async () => {
+      const logEventSpy = vi.spyOn(loggerModule, 'logEvent');
+      // Simulated message with ANSI colors and a prefix
+      const msg = '\x1b[34mDEBUG\x1b[0m [21:05:22] [MESSAGE_BUS] publish: {"type":"test-message"}';
+      const result = await runStreamingCommand('sh', ['-c', `echo '${msg}' >&2`], process.env);
+      
+      expect(result.status).toBe(0);
+      expect(logEventSpy).toHaveBeenCalledWith('GEMINI_EVENT', {
+        type: 'test-message',
+        _isMessageBus: true
+      });
+      expect(logEventSpy).not.toHaveBeenCalledWith('STDERR', expect.anything());
     });
   });
 });

--- a/tests/utils/exec.test.ts
+++ b/tests/utils/exec.test.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { formatStreamChunk, createLineForwarder, runStreamingCommand } from '../../src/utils/exec';
+import * as loggerModule from '../../src/utils/logger';
 
 describe('exec utility', () => {
   describe('formatStreamChunk', () => {
@@ -64,6 +65,21 @@ describe('exec utility', () => {
       const result = await runStreamingCommand('pwd', [], process.env, '/tmp');
       expect(result.status).toBe(0);
       expect(fs.realpathSync(result.stdout.trim())).toBe(fs.realpathSync('/tmp'));
+    });
+
+    it('should intercept MESSAGE_BUS messages in stderr', async () => {
+      const logEventSpy = vi.spyOn(loggerModule, 'logEvent');
+      const msg = '[MESSAGE_BUS] publish: {"type":"tool-calls-update","toolCalls":[],"schedulerId":"root"}';
+      const result = await runStreamingCommand('sh', ['-c', `echo '${msg}' >&2`], process.env);
+      
+      expect(result.status).toBe(0);
+      expect(logEventSpy).toHaveBeenCalledWith('GEMINI_EVENT', {
+        type: 'tool-calls-update',
+        toolCalls: [],
+        schedulerId: 'root'
+      });
+      // Should still be in the result.stderr buffer
+      expect(result.stderr).toContain(msg);
     });
   });
 });

--- a/tests/utils/parser.test.ts
+++ b/tests/utils/parser.test.ts
@@ -53,4 +53,20 @@ some suffix
     expect(events[0].event).toBe('session_start');
     expect(events[1].event).toBe('session_end');
   });
+
+  it('should parse message bus debug logs', () => {
+    const logs = `
+[stderr] [MESSAGE_BUS] publish: {"type":"tool-calls-update","toolCalls":[],"schedulerId":"root"}
+some other log
+[stderr] [MESSAGE_BUS] publish: {"type":"tool-calls-update","toolCalls":[{"id":"call_1","function":{"name":"read_file"}}],"schedulerId":"root"}
+    `;
+    const events = parseLogs(logs);
+    expect(events).toHaveLength(2);
+    expect(events[0].event).toBe('GEMINI_EVENT');
+    expect(events[0].data.type).toBe('tool-calls-update');
+    expect(events[0].data._isMessageBus).toBe(true);
+    expect(events[1].event).toBe('GEMINI_EVENT');
+    expect(events[1].data.toolCalls).toHaveLength(1);
+    expect(events[1].data.toolCalls[0].function.name).toBe('read_file');
+  });
 });


### PR DESCRIPTION
This PR implements support for intercepting `MESSAGE_BUS` debug messages from `stderr` and turning them into UI events, so that they no longer appear in the output terminal but instead are handled in the observability timeline.

Closes #139