### PR TITLE
Tighten Zod schemas by removing unnecessary .nullable() and .optional() (#157)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,8 @@ function loadIssueState(repository: string, issueNumber: number): {
     labels: z.array(z.object({ name: z.string() })),
     body: z.string().nullable().transform(val => val ?? ''),
     comments: z.number().default(0),
-    html_url: z.string().default(''),
-    node_id: z.string().default(''),
+    html_url: z.string(),
+    node_id: z.string(),
   });
 
   const parsed = IssueStateSchema.parse(JSON.parse(issueData.stdout));

--- a/src/recover-orphans.ts
+++ b/src/recover-orphans.ts
@@ -23,7 +23,7 @@ interface RecoverOptions {
 }
 
 const WorkflowRunsResponseSchema = z.object({
-  workflow_runs: z.array(ConductorWorkflowRunSchema).optional(),
+  workflow_runs: z.array(ConductorWorkflowRunSchema),
 }).passthrough();
 
 
@@ -38,24 +38,23 @@ const ProjectItemsQuerySchema = z.object({
         }),
         nodes: z.array(z.object({
           status: z.object({
-            name: z.string().nullable().optional(),
-          }).nullable().optional(),
+            name: z.string().nullable(),
+          }).nullable(),
           persona: z.object({
-            name: z.string().nullable().optional(),
-          }).nullable().optional(),
+            name: z.string().nullable(),
+          }).nullable(),
           content: z.object({
-            id: z.string().nullable().optional(),
-            number: z.number().nullable().optional(),
+            id: z.string().nullable(),
+            number: z.number().nullable(),
             repository: z.object({
-              nameWithOwner: z.string().nullable().optional(),
-            }).nullable().optional(),
-          }).nullable().optional(),
+              nameWithOwner: z.string().nullable(),
+            }).nullable(),
+          }).nullable(),
         })),
       }),
-    }).nullable().optional(),
-  }).nullable().optional(),
+    }),
+  }),
 }).passthrough();
-
 const GraphqlResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) => z.object({
   data: dataSchema.optional(),
   errors: z.array(z.object({ message: z.string() })).optional(),
@@ -247,7 +246,7 @@ async function loadWorkflowRuns(token: string): Promise<ConductorWorkflowRun[]> 
     `/repos/${TARGET_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=100`,
     token
   );
-  return data.workflow_runs || [];
+  return data.workflow_runs;
 }
 
 async function dispatchRecovery(item: ProjectIssueItem, token: string): Promise<void> {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -11,12 +11,12 @@ export const GitHubEventSchema = z.object({
       name: z.string()
     })),
     body: z.string().default(''),
-    html_url: z.string().optional(),
-    node_id: z.string().optional(),
+    html_url: z.string(),
+    node_id: z.string(),
   }).optional(),
   comment: z.object({
     body: z.string(),
-    html_url: z.string().optional(),
+    html_url: z.string(),
   }).optional(),
   client_payload: z.object({
     repository: z.string().optional(),

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -12,7 +12,7 @@ export interface ProjectIssueItem {
 
 export const ConductorWorkflowRunSchema = z.object({
   status: z.string(),
-  display_title: z.string().nullable().optional(),
+  display_title: z.string(),
 }).passthrough();
 
 export type ConductorWorkflowRun = z.infer<typeof ConductorWorkflowRunSchema>;
@@ -25,9 +25,7 @@ export interface RunTarget {
 const CONDUCTOR_RUN_TITLE = /^Conductor \[(.+)\] Issue #(\d+)\b/;
 const RECOVERY_RUN_SUFFIX = 'Event: schedule (recover_orphaned_in_progress)';
 
-export function parseRunTarget(displayTitle?: string | null): RunTarget | null {
-  if (!displayTitle) return null;
-
+export function parseRunTarget(displayTitle: string): RunTarget | null {
   const match = displayTitle.match(CONDUCTOR_RUN_TITLE);
   if (!match) return null;
 
@@ -42,7 +40,7 @@ export function normalizePersona(persona?: string | null): 'conductor' | 'coder'
 }
 
 export function isRecoveryRun(run: ConductorWorkflowRun): boolean {
-  return typeof run.display_title === 'string' && run.display_title.includes(RECOVERY_RUN_SUFFIX);
+  return run.display_title.includes(RECOVERY_RUN_SUFFIX);
 }
 
 export function hasActiveRun(item: ProjectIssueItem, runs: ConductorWorkflowRun[]): boolean {


### PR DESCRIPTION
Audited and tightened Zod schemas across the codebase to reduce the use of `.nullable()` and `.optional()` where they were unnecessary.

Key changes:
- **src/utils/recover.ts**: `ConductorWorkflowRunSchema.display_title` is now a mandatory string. Simplified `parseRunTarget` and `isRecoveryRun` accordingly.
- **src/recover-orphans.ts**:
    - `WorkflowRunsResponseSchema.workflow_runs` is now mandatory.
    - `ProjectItemsQuerySchema` is stricter: `organization` and `projectV2` are mandatory. Fields like `status`, `persona`, and `content` are no longer optional (though still nullable to handle non-issue items).
    - Simplified `loadWorkflowRuns` to return data directly.
- **src/utils/github.ts**: `GitHubEventSchema` now requires `html_url` and `node_id` when an `issue` is present, and `html_url` when a `comment` is present.
- **src/index.ts**: `IssueStateSchema` now requires `html_url` and `node_id`.

Verified that all 63 unit tests passed after these changes.

Closes #157