### PR TITLE
[#165] Tighten types for buildProjectDispatchPayload

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -145,7 +145,7 @@ async function githubRest(path, token, init = {}) {
   return text.trim() ? JSON.parse(text) : undefined;
 }
 
-async function dispatchProjectActivation(repository, issueNumber, token, eventName = null, action = null, issueNodeId = null, projectNumber = null, projectUrl = null, persona = null) {
+async function dispatchProjectActivation(repository, issueNumber, token, eventName, action, issueNodeId, projectNumber, projectUrl, persona = null) {
   const response = await fetch(`https://api.github.com/repos/${TARGET_REPO}/dispatches`, {
     method: "POST",
     headers: {
@@ -310,11 +310,13 @@ exports.githubProjectsV2Webhook = onRequest(
       const statusName = item?.status?.name;
       const personaName = item?.persona?.name;
 
-      if (!issueNumber || !repositoryName) {
+      if (!issueNumber || !repositoryName || !issueNodeId || !projectUrl) {
         logger.info("Ignoring unrelated project item", {
           deliveryId,
           repositoryName,
-          issueNumber
+          issueNumber,
+          issueNodeId,
+          projectUrl
         });
         res.status(204).send("");
         return;

--- a/functions/project-dispatch.js
+++ b/functions/project-dispatch.js
@@ -10,26 +10,36 @@ function normalizeDispatchPersona(persona) {
 }
 
 /**
+ * Justification for buildProjectDispatchPayload fields:
+ * - repository: REQUIRED. Identifies the target repository for the orchestrated task.
+ * - issueNumber: REQUIRED. Identifies the specific issue being addressed.
+ * - issueNodeId: REQUIRED. Needed for GraphQL mutations in downstream agents.
+ * - projectNumber: REQUIRED. Identifies the project board context.
+ * - projectUrl: REQUIRED. Used to determine the project owner and for referencing.
+ * - eventName: REQUIRED. Identifies the trigger event source.
+ * - action: REQUIRED. Identifies the specific action within the event.
+ * - persona: OPTIONAL. May be unset in the project board; omitted if null/invalid to allow receiver defaults.
+ *
  * @param {{
  *   repository: string,
  *   issueNumber: number,
- *   issueNodeId?: string | null,
- *   projectNumber?: number | null,
- *   projectUrl?: string | null,
+ *   issueNodeId: string,
+ *   projectNumber: number,
+ *   projectUrl: string,
  *   persona?: unknown,
- *   eventName?: string | null,
- *   action?: string | null
+ *   eventName: string,
+ *   action: string
  * }} args
  */
 function buildProjectDispatchPayload(args) {
   const clientPayload = {
     repository: args.repository,
     issue_number: args.issueNumber,
-    issue_node_id: args.issueNodeId ?? null,
-    project_number: args.projectNumber ?? null,
-    project_url: args.projectUrl ?? null,
-    event_name: args.eventName ?? null,
-    action: args.action ?? null
+    issue_node_id: args.issueNodeId,
+    project_number: args.projectNumber,
+    project_url: args.projectUrl,
+    event_name: args.eventName,
+    action: args.action
   };
 
   const persona = normalizeDispatchPersona(args.persona);

--- a/tests/utils/project-dispatch.test.ts
+++ b/tests/utils/project-dispatch.test.ts
@@ -23,7 +23,12 @@ describe('project dispatch payload', () => {
     const payload = buildProjectDispatchPayload({
       repository: 'LLM-Orchestration/conductor',
       issueNumber: 157,
-      persona: 'coder'
+      issueNodeId: 'I_123',
+      projectNumber: 1,
+      projectUrl: 'https://github.com/orgs/LLM-Orchestration/projects/1',
+      persona: 'coder',
+      eventName: 'projects_v2_item',
+      action: 'edited'
     });
 
     expect(payload.client_payload.persona).toBe('coder');


### PR DESCRIPTION
Tightens the JSDoc and implementation of buildProjectDispatchPayload to make issueNodeId, projectNumber, projectUrl, eventName, and action required. These fields are essential for downstream agents and are always provided in the bridge flow.

Tasks:
- Updated JSDoc and removed ?? null coalescing in functions/project-dispatch.js.
- Added justification comments in functions/project-dispatch.js.
- Updated dispatchProjectActivation signature and githubProjectsV2Webhook validation in functions/index.js.
- Updated tests/utils/project-dispatch.test.ts to include required fields.

Closes #165