### PR TITLE
Fix Zod validation error for null persona

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -145,7 +145,7 @@ async function githubRest(path, token, init = {}) {
   return text.trim() ? JSON.parse(text) : undefined;
 }
 
-async function dispatchProjectActivation(repository, issueNumber, token, eventName, action, issueNodeId, projectNumber, projectUrl, persona = null) {
+async function dispatchProjectActivation(repository, issueNumber, token, eventName, action, issueNodeId, projectNumber, projectUrl, persona = undefined) {
   const response = await fetch(`https://api.github.com/repos/${TARGET_REPO}/dispatches`, {
     method: "POST",
     headers: {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -25,7 +25,7 @@ export const GitHubEventSchema = z.object({
     project_item_id: z.string().optional(),
     project_number: z.number().optional(),
     project_url: z.string().optional(),
-    persona: z.string().optional(),
+    persona: z.string().nullable().optional(),
     event_name: z.string().optional(),
     action: z.string().optional(),
     last_comment_url: z.string().optional(),

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -1,10 +1,49 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
-import { extractEventData, GitHubEvent, extractMediaUrls, collectAllMediaUrls, injectMediaPaths, postPickupNote } from '../../src/utils/github';
+import { extractEventData, GitHubEvent, extractMediaUrls, collectAllMediaUrls, injectMediaPaths, postPickupNote, GitHubEventSchema } from '../../src/utils/github';
 
 vi.mock('child_process', () => ({
   spawnSync: vi.fn(() => ({ status: 0 }))
 }));
+
+describe('GitHubEventSchema', () => {
+  it('should accept persona as a string', () => {
+    const payload = {
+      client_payload: {
+        persona: 'coder'
+      }
+    };
+    const result = GitHubEventSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.client_payload?.persona).toBe('coder');
+    }
+  });
+
+  it('should accept persona as undefined', () => {
+    const payload = {
+      client_payload: {}
+    };
+    const result = GitHubEventSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.client_payload?.persona).toBeUndefined();
+    }
+  });
+
+  it('should accept persona as null', () => {
+    const payload = {
+      client_payload: {
+        persona: null
+      }
+    };
+    const result = GitHubEventSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.client_payload?.persona).toBeNull();
+    }
+  });
+});
 
 describe('postPickupNote', () => {
   beforeEach(() => {


### PR DESCRIPTION
Addresses the issue where dragging an item into 'In Progress' caused a Zod validation failure due to `persona: null` in the client payload.

Changes:
- Updated `GitHubEventSchema` in `src/utils/github.ts` to allow `null` for the `persona` field.
- Updated `dispatchProjectActivation` in `functions/index.js` to default `persona` to `undefined`.
- Added test cases in `tests/utils/github.test.ts` for string, null, and undefined persona values.
- Performed minor refactoring of Gemini event types and UI to be more robust.

Closes #179