### PR TITLE
[#184] Sanitize comment bodies to remove null bytes and prevent crash…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 	postPickupNote,
 } from "./utils/github";
 import { logEvent, logger } from "./utils/logger";
+import { sanitize } from "./utils/sanitize";
 
 function verifyGitHubCli(repository: string, issueNumber: number): string {
 	const repoCheck = spawnSync(
@@ -81,7 +82,7 @@ ${failureDetails}
 				"-R",
 				repository,
 				"--body",
-				body,
+				sanitize(body),
 			],
 			{
 				stdio: "inherit",
@@ -688,7 +689,7 @@ ${snippet}
 						"-R",
 						repository,
 						"--body",
-						body,
+						sanitize(body),
 					],
 					{
 						stdio: "inherit",

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { z } from "zod";
 import { logger } from "./logger";
+import { sanitize } from "./sanitize";
 
 export const GitHubEventSchema = z
 	.object({
@@ -182,7 +183,7 @@ The **${persona}** has ${pickupText} and is working on **${branch}**.`;
 				"-R",
 				repository,
 				"--body",
-				body,
+				sanitize(body),
 			],
 			{
 				stdio: "inherit",

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,8 @@
+/**
+ * Removes null bytes from a string to prevent errors when passing as command line arguments.
+ * Node.js child_process functions (like spawn, spawnSync, exec) will throw an error
+ * if any argument contains a null byte (\u0000).
+ */
+export function sanitize(str: string): string {
+	return str.replace(/\0/g, "");
+}

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { sanitize } from "../../src/utils/sanitize";
+
+describe("sanitize", () => {
+	it("removes null bytes from a string", () => {
+		const input = "hello\0world\0";
+		const expected = "helloworld";
+		expect(sanitize(input)).toBe(expected);
+	});
+
+	it("returns the same string if no null bytes are present", () => {
+		const input = "hello world";
+		expect(sanitize(input)).toBe(input);
+	});
+
+	it("handles empty strings", () => {
+		expect(sanitize("")).toBe("");
+	});
+});


### PR DESCRIPTION
…es in spawnSync