### PR TITLE
[#172] Implement boolean complexity lint rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,7 @@
 - **Mandatory Helper**: Every E2E test MUST use the `TestStepHelper` for all test steps.
 - **Visual Verification**: Every test step MUST include a visual verification via `toHaveScreenshot()`. This is an ABSOLUTE REQUIREMENT to ensure "Zero-Pixel Tolerance".
 - **Gemini CLI Output**: As of #129, Gemini CLI is invoked with `-o stream-json`. Conductor parses these events and emits `GEMINI_EVENT` for observability.
+
+## Coding Standards
+
+- **Boolean Complexity**: Boolean expressions MUST be limited to at most two logical operations (`&&`, `||`). Expressions that are more complex must be broken down into intermediate variables or refactored for clarity. This is enforced by a custom lint script.

--- a/functions/index.js
+++ b/functions/index.js
@@ -335,7 +335,14 @@ exports.githubProjectsV2Webhook = onRequest(
 			const statusName = item?.status?.name;
 			const personaName = item?.persona?.name;
 
-			if (!issueNumber || !repositoryName || !issueNodeId || !projectUrl) {
+			const hasMissingFields = [
+				issueNumber,
+				repositoryName,
+				issueNodeId,
+				projectUrl,
+			].some((field) => !field);
+
+			if (hasMissingFields) {
 				logger.info("Ignoring unrelated project item", {
 					deliveryId,
 					repositoryName,
@@ -359,11 +366,13 @@ exports.githubProjectsV2Webhook = onRequest(
 
 			// Trigger if Status is "In Progress" (on creation OR on edit to Status)
 			// OR if Persona was changed (only on edit)
-			const isStatusTrigger =
-				(action === "created" && statusName === TARGET_STATUS) ||
-				(action === "edited" &&
-					changedFieldName === "Status" &&
-					statusName === TARGET_STATUS);
+			const isCreatedStatus =
+				action === "created" && statusName === TARGET_STATUS;
+			const isEditedStatus =
+				action === "edited" &&
+				changedFieldName === "Status" &&
+				statusName === TARGET_STATUS;
+			const isStatusTrigger = isCreatedStatus || isEditedStatus;
 			const isPersonaTrigger =
 				action === "edited" && changedFieldName === "Persona";
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"prepare": "npm run hooks:install",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",
-		"lint": "biome check .",
+		"lint:complexity": "node scripts/check-boolean-complexity.js",
+		"lint": "biome check . && npm run lint:complexity",
 		"format": "biome format . --write",
 		"test:watch": "vitest",
 		"validate": "npm run build && npm run functions:check && npm run test"

--- a/scripts/check-boolean-complexity.js
+++ b/scripts/check-boolean-complexity.js
@@ -1,0 +1,149 @@
+const ts = require("typescript");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAX_OPERATORS = 2;
+const TARGET_DIRS = ["src", "functions", "observability-ui/src"];
+
+let hasViolations = false;
+
+function isLogicalOperator(kind) {
+	return (
+		kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+		kind === ts.SyntaxKind.BarBarToken
+	);
+}
+
+function countOperators(node) {
+	let count = 0;
+	if (
+		ts.isBinaryExpression(node) &&
+		isLogicalOperator(node.operatorToken.kind)
+	) {
+		count = 1 + countOperators(node.left) + countOperators(node.right);
+	} else if (ts.isParenthesizedExpression(node)) {
+		count = countOperators(node.expression);
+	} else if (
+		ts.isPrefixUnaryExpression(node) &&
+		node.operator === ts.SyntaxKind.ExclamationToken
+	) {
+		count = countOperators(node.operand);
+	}
+	return count;
+}
+
+/**
+ * For a given logical binary expression, we want to find the "root" of the contiguous
+ * logical expression so we don't report the same violation multiple times for sub-expressions.
+ */
+function isRootLogicalExpression(node) {
+	if (
+		!ts.isBinaryExpression(node) ||
+		!isLogicalOperator(node.operatorToken.kind)
+	) {
+		return false;
+	}
+
+	const parent = node.parent;
+	if (!parent) return true;
+
+	if (
+		ts.isBinaryExpression(parent) &&
+		isLogicalOperator(parent.operatorToken.kind)
+	) {
+		return false;
+	}
+
+	if (ts.isParenthesizedExpression(parent)) {
+		// If it's wrapped in parens, we need to check the parent of the parens
+		let current = parent;
+		while (current.parent && ts.isParenthesizedExpression(current.parent)) {
+			current = current.parent;
+		}
+		if (
+			current.parent &&
+			ts.isBinaryExpression(current.parent) &&
+			isLogicalOperator(current.parent.operatorToken.kind)
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function checkTsJsFile(filePath) {
+	const sourceText = fs.readFileSync(filePath, "utf8");
+	const sourceFile = ts.createSourceFile(
+		filePath,
+		sourceText,
+		ts.ScriptTarget.Latest,
+		true,
+	);
+
+	function visit(node) {
+		if (isRootLogicalExpression(node)) {
+			const count = countOperators(node);
+			if (count > MAX_OPERATORS) {
+				const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+					node.getStart(),
+				);
+				console.log(
+					`${filePath}:${line + 1}:${character + 1}: Complex boolean expression found (${count} operators)`,
+				);
+				hasViolations = true;
+			}
+		}
+		ts.forEachChild(node, visit);
+	}
+
+	visit(sourceFile);
+}
+
+function checkSvelteFile(filePath) {
+	const sourceText = fs.readFileSync(filePath, "utf8");
+	const lines = sourceText.split("\n");
+
+	lines.forEach((line, index) => {
+		// Split line by Svelte expression boundaries to avoid counting operators
+		// from separate expressions on the same line as a single complex expression.
+		const expressions = line.split(/\{|\}/);
+		expressions.forEach((expr) => {
+			const matches = expr.match(/&&|\|\|/g);
+			if (matches && matches.length > MAX_OPERATORS) {
+				console.log(
+					`${filePath}:${index + 1}: Potential complex boolean expression found (${matches.length} operators)`,
+				);
+				hasViolations = true;
+			}
+		});
+	});
+}
+
+function walkDir(dir) {
+	if (!fs.existsSync(dir)) return;
+	const files = fs.readdirSync(dir);
+	for (const file of files) {
+		const filePath = path.join(dir, file);
+		const stat = fs.statSync(filePath);
+		if (stat.isDirectory()) {
+			walkDir(filePath);
+		} else {
+			const ext = path.extname(filePath);
+			if (ext === ".ts" || ext === ".js") {
+				checkTsJsFile(filePath);
+			} else if (ext === ".svelte") {
+				checkSvelteFile(filePath);
+			}
+		}
+	}
+}
+
+TARGET_DIRS.forEach(walkDir);
+
+if (hasViolations) {
+	process.exit(1);
+} else {
+	console.log("No complex boolean expressions found.");
+	process.exit(0);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,13 @@ function verifyGitHubCli(repository: string, issueNumber: number): string {
 		});
 
 		const failureDetails = (
-			repoCheck.stderr ||
-			repoCheck.stdout ||
-			authStatus.stderr ||
-			authStatus.stdout ||
-			"No gh output captured"
+			[
+				repoCheck.stderr,
+				repoCheck.stdout,
+				authStatus.stderr,
+				authStatus.stdout,
+				"No gh output captured",
+			].find(Boolean) || ""
 		).trim();
 
 		logger.error(`GitHub CLI preflight failed for ${repository}.`);

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -65,9 +65,8 @@ export function toProjectIssueItem(
 	const issueNodeId = node.content?.id;
 	const status = node.status?.name;
 
-	if (!repository || !issueNumber || !issueNodeId || !status) {
-		return null;
-	}
+	if (!repository || !issueNumber) return null;
+	if (!issueNodeId || !status) return null;
 
 	return {
 		repository,

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { sanitize } from "../../src/utils/sanitize";
 
 describe("sanitize", () => {


### PR DESCRIPTION
This PR implements a custom lint rule to enforce a limit on boolean expression complexity (Issue #172).

### Changes:
1. **New Lint Script**: Created `scripts/check-boolean-complexity.js` which uses the TypeScript AST to detect boolean expressions with more than 2 logical operators (`&&`, `||`).
2. **Enhanced Svelte Check**: Included a regex-based check for `.svelte` files.
3. **Updated package.json**: Added `lint:complexity` script and integrated it into the main `lint` command.
4. **Refactored Violations**:
   - `src/utils/recover.ts`: Split complex checks into separate `if` statements.
   - `functions/index.js`: Refactored complex logic using intermediate variables and `.some()`.
   - `src/index.ts`: Simplified multiple `||` operators using `[].find(Boolean)`.
5. **Documentation**: Added boolean complexity standards to `AGENTS.md`.

Closes #172