### PR TITLE
Remove undefined from JsonValue and JsonValueSchema

### DIFF
--- a/observability-ui/src/lib/types.ts
+++ b/observability-ui/src/lib/types.ts
@@ -10,7 +10,6 @@ export type JsonValue =
 	| number
 	| boolean
 	| null
-	| undefined
 	| { [key: string]: JsonValue }
 	| JsonValue[];
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,6 @@ export type JsonValue =
 	| number
 	| boolean
 	| null
-	| undefined
 	| { [key: string]: JsonValue }
 	| JsonValue[];
 
@@ -21,7 +20,6 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 		z.number(),
 		z.boolean(),
 		z.null(),
-		z.undefined(),
 		z.record(z.string(), JsonValueSchema),
 		z.array(JsonValueSchema),
 	]),


### PR DESCRIPTION
Closes #174. This PR removes `undefined` from the `JsonValue` type and `JsonValueSchema` to strictly adhere to the JSON specification.