### PR TITLE
[#200] Allow shell commands with redirection in CI

### DIFF
--- a/.gemini/policies/conductor-policy.toml
+++ b/.gemini/policies/conductor-policy.toml
@@ -1,0 +1,5 @@
+[[rule]]
+toolName = "run_shell_command"
+decision = "allow"
+priority = 500
+allowRedirection = true


### PR DESCRIPTION
This PR adds a gemini-cli policy to allow shell commands with redirection and operators (&&, |, >) to run without manual confirmation in non-interactive mode.

Verification:
- Confirmed `.gemini/policies/conductor-policy.toml` exists with `allowRedirection = true`.
- Manually verified that commands like `echo "test" > /tmp/test && cat /tmp/test` and `ls | grep .gemini` run without error in the current environment.

Closes #200