### PR TITLE
Fix Gemini OAuth auth method setup

### DIFF
--- a/scripts/prepare-gemini-auth.sh
+++ b/scripts/prepare-gemini-auth.sh
@@ -13,6 +13,24 @@ if [ -n "${GEMINI_OAUTH_CREDS_JSON:-}" ]; then
   node -e 'JSON.parse(process.env.GEMINI_OAUTH_CREDS_JSON || "")'
   printf '%s' "$GEMINI_OAUTH_CREDS_JSON" > "$gemini_dir/oauth_creds.json"
   chmod 600 "$gemini_dir/oauth_creds.json"
+  node - "$gemini_dir/settings.json" <<'NODE'
+const fs = require("fs");
+
+const settingsPath = process.argv[2];
+let settings = {};
+
+try {
+  settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+} catch (_) {
+  settings = {};
+}
+
+settings.security ??= {};
+settings.security.auth ??= {};
+settings.security.auth.selectedType = "oauth-personal";
+
+fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+NODE
   echo "Using Gemini OAuth credentials from GEMINI_OAUTH_CREDS_JSON."
   exit 0
 fi


### PR DESCRIPTION
## Summary
- configure Gemini CLI settings for the OAuth credentials path by setting `security.auth.selectedType` to `oauth-personal`
- preserve OAuth preference when both OAuth credentials and the API key secret are present
- keep the existing `.geminiignore`/`projects.json` setup unchanged

Related to #207.

## Validation
- targeted temp-HOME OAuth setup test writes `~/.gemini/oauth_creds.json` and `~/.gemini/settings.json`
- targeted test with both `GEMINI_OAUTH_CREDS_JSON` and `GEMINI_API_KEY_SECRET` confirms OAuth is selected first and `GEMINI_API_KEY` is not written to `GITHUB_ENV`
- `npm run build`
- `npm run validate` passed during pre-push

Note: a standalone `npm run lint` was also attempted and still reports pre-existing Svelte diagnostics under `observability-ui`, unrelated to this shell script change.
