### PR TITLE
Fix Project V2 handoff item lookup

### DIFF
--- a/scripts/handoff-utils.sh
+++ b/scripts/handoff-utils.sh
@@ -151,6 +151,99 @@ strip_local_media_markers() {
   mv "$tmp_file" "$body_file"
 }
 
+find_project_item_id_by_issue_content() {
+  local owner_kind
+  local owner_query
+  local after=""
+  local response
+  local item_id
+  local page_info
+  local end_cursor
+  local -a graphql_args
+
+  if [ -z "${issue_node_id:-}" ]; then
+    return 0
+  fi
+
+  owner_kind="$(node -e "
+const url = process.argv[1] || '';
+const match = url.match(/github\.com\/(orgs|users)\//);
+process.stdout.write(match ? match[1] : '');
+" "$project_url")"
+
+  case "$owner_kind" in
+    orgs)
+      owner_query='organization(login: $owner)'
+      ;;
+    users)
+      owner_query='user(login: $owner)'
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  while :; do
+    graphql_args=(-f owner="$project_owner" -F number="$project_number" -f query="
+      query(\$owner: String!, \$number: Int!, \$after: String) {
+        $owner_query {
+          projectV2(number: \$number) {
+            items(first: 100, after: \$after) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                id
+                content {
+                  ... on Issue {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }")
+    if [ -n "$after" ]; then
+      graphql_args+=(-f after="$after")
+    fi
+
+    response="$(gh api graphql "${graphql_args[@]}")"
+
+    item_id="$(printf '%s' "$response" | node -e "
+const fs = require('fs');
+const issueNodeId = process.argv[1];
+const body = JSON.parse(fs.readFileSync(0, 'utf8'));
+const project = body.data?.organization?.projectV2 || body.data?.user?.projectV2;
+const item = project?.items?.nodes?.find((node) => node.content?.id === issueNodeId);
+if (item?.id) process.stdout.write(item.id);
+" "$issue_node_id")"
+
+    if [ -n "$item_id" ]; then
+      echo "$item_id"
+      return 0
+    fi
+
+    page_info="$(printf '%s' "$response" | node -e "
+const fs = require('fs');
+const body = JSON.parse(fs.readFileSync(0, 'utf8'));
+const project = body.data?.organization?.projectV2 || body.data?.user?.projectV2;
+const pageInfo = project?.items?.pageInfo;
+if (pageInfo?.hasNextPage && pageInfo?.endCursor) {
+  process.stdout.write(`${pageInfo.endCursor}`);
+}
+")"
+
+    end_cursor="$page_info"
+    if [ -z "$end_cursor" ]; then
+      break
+    fi
+
+    after="$end_cursor"
+  done
+}
+
 update_project_v2_field() {
   local field_name="$1"
   local option_name="$2"
@@ -176,7 +269,7 @@ process.stdout.write(match ? match[2] : '');
 
   if [ -z "$item_id" ]; then
     echo "Finding project item for issue $issue_number in repository $target_repo in project $project_number"
-    # Use targeted GraphQL via gh api graphql
+    # Prefer the issue's projectItems connection when GitHub exposes it.
     item_id=$(gh api graphql -f id="$issue_node_id" -f query='
       query($id: ID!) {
         node(id: $id) {
@@ -192,6 +285,11 @@ process.stdout.write(match ? match[2] : '');
           }
         }
       }' --jq ".data.node.projectItems.nodes[] | select(.project.number == $project_number) | .id" | head -n 1)
+  fi
+
+  if [ -z "$item_id" ] || [ "$item_id" == "null" ]; then
+    echo "Issue projectItems lookup did not find the item; scanning project content for issue node $issue_node_id"
+    item_id="$(find_project_item_id_by_issue_content)"
   fi
 
   if [ -z "$item_id" ] || [ "$item_id" == "null" ]; then

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -133,9 +133,10 @@ if [ "$verified" -ne 1 ]; then
   exit 1
 fi
 
-gh issue comment "$issue_number" -R "$target_repo" --body-file "$body_file"
-
-# Update Project V2 Persona field if project info is available
+# Update Project V2 Persona field before posting the handoff comment, so a
+# failed project lookup does not leave a misleading delegation comment behind.
 if [ -n "$project_number" ] && [ "$target" != "human" ]; then
   update_project_v2_field "Persona" "$target" ".persona"
 fi
+
+gh issue comment "$issue_number" -R "$target_repo" --body-file "$body_file"

--- a/src/recover-orphans.ts
+++ b/src/recover-orphans.ts
@@ -43,6 +43,7 @@ const ProjectItemsQuerySchema = z
 					}),
 					nodes: z.array(
 						z.object({
+							id: z.string().nullable().optional(),
 							status: z
 								.object({
 									name: z.string().nullable(),
@@ -211,6 +212,7 @@ async function loadProjectItems(token: string): Promise<ProjectIssueItem[]> {
               endCursor
             }
             nodes {
+              id
               status: fieldValueByName(name: "Status") {
                 ... on ProjectV2ItemFieldSingleSelectValue {
                   name
@@ -291,6 +293,7 @@ async function dispatchRecovery(
 				repository: item.repository,
 				issue_number: item.issueNumber,
 				issue_node_id: item.issueNodeId,
+				project_item_id: item.projectItemId,
 				project_number: item.projectNumber,
 				project_url: item.projectUrl,
 				persona: normalizePersona(item.persona),

--- a/src/utils/recover.ts
+++ b/src/utils/recover.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export interface ProjectIssueItem {
+	projectItemId: string;
 	repository: string;
 	issueNumber: number;
 	issueNodeId: string;
@@ -11,6 +12,7 @@ export interface ProjectIssueItem {
 }
 
 export interface ProjectItemNode {
+	id?: string | null;
 	status?: { name?: string | null } | null;
 	persona?: { name?: string | null } | null;
 	content?: {
@@ -63,12 +65,14 @@ export function toProjectIssueItem(
 	const repository = node.content?.repository?.nameWithOwner;
 	const issueNumber = node.content?.number;
 	const issueNodeId = node.content?.id;
+	const projectItemId = node.id;
 	const status = node.status?.name;
 
 	if (!repository || !issueNumber) return null;
-	if (!issueNodeId || !status) return null;
+	if (!issueNodeId || !projectItemId || !status) return null;
 
 	return {
+		projectItemId,
 		repository,
 		issueNumber,
 		issueNodeId,

--- a/tests/handoff_test.sh
+++ b/tests/handoff_test.sh
@@ -128,7 +128,15 @@ case "\$*" in
     ;;
   "api"*"graphql"*)
     if [ -f "$TEST_DIR/mock_project_item_missing" ]; then
+      if echo "\$*" | grep -q -- "--jq"; then
+        echo ""
+      else
+        echo '{"data":{"organization":{"projectV2":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+      fi
+    elif [ -f "$TEST_DIR/mock_issue_projectitems_missing" ] && echo "\$*" | grep -q "projectItems"; then
       echo ""
+    elif echo "\$*" | grep -q "projectV2"; then
+      echo '{"data":{"organization":{"projectV2":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"ITEM_123","content":{"id":"I_123"}}]}}}}}'
     elif echo "\$*" | grep -q "projectItems" || echo "\$*" | grep -q "query"; then
       if echo "\$*" | grep -q "ProjectV2Item"; then
         echo "coder"
@@ -171,6 +179,28 @@ else
   fi
 fi
 rm "$TEST_DIR/mock_project_item_missing"
+
+# Test 1b: Fall back to scanning project contents when Issue.projectItems is empty
+echo "Running Test 1b: Use project content scan when reverse issue lookup is empty..."
+touch "$TEST_DIR/mock_issue_projectitems_missing"
+rm -f "$TEST_DIR/gh_calls"
+if bash scripts/handoff.sh coder 0 < "$TEST_DIR/comment.md" > "$TEST_DIR/stdout" 2> "$TEST_DIR/stderr"; then
+  if grep -q "Issue projectItems lookup did not find the item; scanning project content for issue node I_123" "$TEST_DIR/stdout" &&
+     grep -q "Project V2 update verified: Persona is now 'coder'" "$TEST_DIR/stdout"; then
+    echo "Success: Test 1b passed"
+  else
+    echo "Error: Test 1b failed with wrong output"
+    cat "$TEST_DIR/stdout"
+    cat "$TEST_DIR/stderr"
+    exit 1
+  fi
+else
+  echo "Error: Test 1b failed (handoff.sh exited with non-zero)"
+  cat "$TEST_DIR/stdout"
+  cat "$TEST_DIR/stderr"
+  exit 1
+fi
+rm "$TEST_DIR/mock_issue_projectitems_missing"
 
 # Test 2: PUSH FAILURE
 echo "Running Test 2: PUSH FAILURE..."

--- a/tests/utils/recover.test.ts
+++ b/tests/utils/recover.test.ts
@@ -47,6 +47,7 @@ describe("recover utils", () => {
 
 	it("detects an active run for a matching issue", () => {
 		const item: ProjectIssueItem = {
+			projectItemId: "PVTI_53",
 			repository: "LLM-Orchestration/conductor",
 			issueNumber: 53,
 			issueNodeId: "I_53",
@@ -70,6 +71,7 @@ describe("recover utils", () => {
 	it("finds only in-progress items without an active conductor run", () => {
 		const items: ProjectIssueItem[] = [
 			{
+				projectItemId: "PVTI_53",
 				repository: "LLM-Orchestration/conductor",
 				issueNumber: 53,
 				issueNodeId: "I_53",
@@ -79,6 +81,7 @@ describe("recover utils", () => {
 				persona: "coder",
 			},
 			{
+				projectItemId: "PVTI_54",
 				repository: "LLM-Orchestration/conductor",
 				issueNumber: 54,
 				issueNodeId: "I_54",
@@ -102,6 +105,7 @@ describe("recover utils", () => {
 
 	it("counts only retry-mechanism attempts for the matching issue", () => {
 		const item: ProjectIssueItem = {
+			projectItemId: "PVTI_53",
 			repository: "LLM-Orchestration/conductor",
 			issueNumber: 53,
 			issueNodeId: "I_53",
@@ -158,7 +162,7 @@ describe("recover utils", () => {
 		).toBeNull();
 	});
 
-	it("maps valid project issue nodes into recoverable items", () => {
+	it("ignores project issue nodes without a project item id", () => {
 		expect(
 			toProjectIssueItem(
 				{
@@ -173,7 +177,27 @@ describe("recover utils", () => {
 				1,
 				"https://github.com/orgs/LLM-Orchestration/projects/1",
 			),
+		).toBeNull();
+	});
+
+	it("maps valid project issue nodes into recoverable items", () => {
+		expect(
+			toProjectIssueItem(
+				{
+					id: "PVTI_157",
+					status: { name: "In Progress" },
+					persona: { name: "coder" },
+					content: {
+						id: "I_157",
+						number: 157,
+						repository: { nameWithOwner: "LLM-Orchestration/conductor" },
+					},
+				},
+				1,
+				"https://github.com/orgs/LLM-Orchestration/projects/1",
+			),
 		).toEqual({
+			projectItemId: "PVTI_157",
 			repository: "LLM-Orchestration/conductor",
 			issueNumber: 157,
 			issueNodeId: "I_157",


### PR DESCRIPTION
## Summary
- add a Project V2 content scan fallback when `Issue.projectItems` does not expose the project item
- pass `project_item_id` through orphan recovery dispatches so recovered runs can update the exact project item directly
- update the Project V2 Persona field before posting the handoff comment to avoid misleading partial handoff comments when project updates fail

## Context
`anicolao/gotfive#4` and duplicate `#5` reproduce a GitHub GraphQL asymmetry: the Project V2 item points to the issue, but the issue's `projectItems` connection returns zero items. The handoff script previously relied only on the reverse issue lookup, so it could update labels/comment while failing to set Project V2 `Persona`, leaving recovery to default back to conductor.

## Validation
- `npm run build`
- `npm run test -- tests/utils/recover.test.ts tests/handoff-validation.test.ts`
- `npm run test`
- `npm run validate`
- real lookup check: project-content fallback resolves `anicolao/gotfive#5` to `PVTI_lADOEGPutc4BUN0Dzgr1mUU`

Note: `npm run lint` still reports unrelated pre-existing formatting issues in `observability-ui/src/routes/approval/+page.svelte` and `tests/e2e/012-mobile-view/012-mobile-view.spec.ts`.
