### PR TITLE
Run Gemini CLI in auto model mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,22 @@ function hasGeminiOAuthCredentials(): boolean {
 	}
 }
 
+export function buildGeminiCliArgs(prompt: string): string[] {
+	return [
+		"-y",
+		"@google/gemini-cli",
+		"--debug",
+		"--model",
+		"auto",
+		"--prompt",
+		prompt,
+		"--approval-mode",
+		"yolo",
+		"-o",
+		"stream-json",
+	];
+}
+
 const CommentSchema = z.object({
 	body: z.string(),
 	html_url: z.string(),
@@ -633,17 +649,7 @@ ENVIRONMENT:
 - If a gh command fails, report the exact command and stderr instead of inferring an authentication problem.`;
 
 			// Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
-			const args = [
-				"-y",
-				"@google/gemini-cli",
-				"--debug",
-				"--prompt",
-				prompt,
-				"--approval-mode",
-				"yolo",
-				"-o",
-				"stream-json",
-			];
+			const args = buildGeminiCliArgs(prompt);
 
 			logger.info("Invoking Gemini CLI...");
 			const childEnv = buildGeminiEnv();

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -2,7 +2,25 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadPrompts } from "../src/index";
+import { buildGeminiCliArgs, loadPrompts } from "../src/index";
+
+describe("buildGeminiCliArgs", () => {
+	it("runs Gemini CLI in auto model mode with stream-json output", () => {
+		expect(buildGeminiCliArgs("test prompt")).toEqual([
+			"-y",
+			"@google/gemini-cli",
+			"--debug",
+			"--model",
+			"auto",
+			"--prompt",
+			"test prompt",
+			"--approval-mode",
+			"yolo",
+			"-o",
+			"stream-json",
+		]);
+	});
+});
 
 describe("loadPrompts", () => {
 	let tmpDir: string;


### PR DESCRIPTION
## Summary
- invoke Gemini CLI with `--model auto` so it can route across available Gemini models instead of relying on the CLI default
- move Gemini CLI argument construction into a small helper
- add a unit test that locks the CLI args to auto model mode and `stream-json` output

## Validation
- `npx -y @google/gemini-cli --help` confirms `--model` is a supported CLI option
- `npm run build`
- `npm run test -- tests/prompts.test.ts`
- `npx biome check src/index.ts tests/prompts.test.ts`
- `npm run validate`
- `npm run lint`
