### PR TITLE
Select Gemini CLI model from quota

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,10 @@ function buildGeminiEnv(): NodeJS.ProcessEnv {
 		if (value) env[key] = value;
 	}
 
+	if (hasGeminiOAuthCredentials()) {
+		return env;
+	}
+
 	if (process.env.GEMINI_API_KEY) {
 		env.GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 		return env;
@@ -157,13 +161,314 @@ function hasGeminiOAuthCredentials(): boolean {
 	}
 }
 
-export function buildGeminiCliArgs(prompt: string): string[] {
+const CODE_ASSIST_ENDPOINT = "https://cloudcode-pa.googleapis.com";
+const CODE_ASSIST_API_VERSION = "v1internal";
+
+export type GeminiCliModel = "auto" | "flash" | "flash-lite" | "pro";
+type GeminiPersona = "conductor" | "coder";
+
+const GeminiOAuthCredentialsSchema = z.object({
+	access_token: z.string().optional(),
+	expiry_date: z.number().optional(),
+	refresh_token: z.string().optional(),
+});
+
+const CodeAssistLoadResponseSchema = z.object({
+	cloudaicompanionProject: z.string().optional(),
+	response: z
+		.object({
+			cloudaicompanionProject: z
+				.object({ id: z.string().optional() })
+				.optional(),
+		})
+		.optional(),
+});
+
+export const GeminiQuotaBucketSchema = z.object({
+	modelId: z.string().optional(),
+	remainingAmount: z.string().optional(),
+	remainingFraction: z.number().optional(),
+	resetTime: z.string().optional(),
+});
+
+const GeminiQuotaResponseSchema = z.object({
+	buckets: z.array(GeminiQuotaBucketSchema).optional(),
+});
+
+type GeminiQuotaBucket = z.infer<typeof GeminiQuotaBucketSchema>;
+type GeminiOAuthClientConfig = { clientId: string; clientSecret: string };
+let cachedGeminiOAuthClientConfig: GeminiOAuthClientConfig | undefined;
+
+function codeAssistMethodUrl(method: string): string {
+	const endpoint = process.env.CODE_ASSIST_ENDPOINT || CODE_ASSIST_ENDPOINT;
+	const version =
+		process.env.CODE_ASSIST_API_VERSION || CODE_ASSIST_API_VERSION;
+	return `${endpoint}/${version}:${method}`;
+}
+
+async function postCodeAssistJson<T>(
+	method: string,
+	accessToken: string,
+	body: unknown,
+): Promise<T> {
+	const response = await fetch(codeAssistMethodUrl(method), {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`Code Assist ${method} failed with ${response.status}: ${text}`,
+		);
+	}
+
+	return (await response.json()) as T;
+}
+
+async function refreshGeminiOAuthAccessToken(
+	refreshToken: string,
+): Promise<string> {
+	const clientConfig = resolveGeminiOAuthClientConfig();
+	const body = new URLSearchParams({
+		client_id: clientConfig.clientId,
+		client_secret: clientConfig.clientSecret,
+		refresh_token: refreshToken,
+		grant_type: "refresh_token",
+	});
+
+	const response = await fetch("https://oauth2.googleapis.com/token", {
+		method: "POST",
+		body,
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`Gemini OAuth refresh failed with ${response.status}: ${text}`,
+		);
+	}
+
+	const parsed = z
+		.object({ access_token: z.string() })
+		.parse(await response.json());
+	return parsed.access_token;
+}
+
+function resolveGeminiOAuthClientConfig(): GeminiOAuthClientConfig {
+	if (cachedGeminiOAuthClientConfig) return cachedGeminiOAuthClientConfig;
+
+	const script = `
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const geminiBin = cp.execFileSync("sh", ["-c", "command -v gemini"], { encoding: "utf8" }).trim();
+const geminiEntry = fs.realpathSync(geminiBin);
+const packageRoot = path.dirname(path.dirname(geminiEntry));
+const bundleDir = path.join(packageRoot, "bundle");
+const sources = fs.readdirSync(bundleDir)
+  .filter((file) => file.endsWith(".js"))
+  .map((file) => fs.readFileSync(path.join(bundleDir, file), "utf8"))
+  .join("\\n");
+
+const clientId = sources.match(/OAUTH_CLIENT_ID\\s*=\\s*["']([^"']+)["']/)?.[1];
+const clientSecret = sources.match(/OAUTH_CLIENT_SECRET\\s*=\\s*["']([^"']+)["']/)?.[1];
+
+if (!clientId || !clientSecret) {
+  throw new Error("Unable to locate Gemini CLI OAuth client configuration.");
+}
+
+process.stdout.write(JSON.stringify({ clientId, clientSecret }));
+`;
+
+	const result = spawnSync(
+		"npx",
+		["-y", "-p", "@google/gemini-cli", "node", "-e", script],
+		{
+			encoding: "utf8",
+			env: process.env,
+		},
+	);
+
+	if (result.status !== 0 || !result.stdout.trim()) {
+		throw new Error(
+			`Unable to inspect Gemini CLI OAuth configuration: ${(
+				result.stderr || result.stdout || "No output captured"
+			).trim()}`,
+		);
+	}
+
+	cachedGeminiOAuthClientConfig = z
+		.object({ clientId: z.string(), clientSecret: z.string() })
+		.parse(JSON.parse(result.stdout));
+	return cachedGeminiOAuthClientConfig;
+}
+
+async function getGeminiOAuthAccessToken(): Promise<string | null> {
+	const home = process.env.HOME;
+	if (!home) return null;
+
+	const credsPath = path.join(home, ".gemini", "oauth_creds.json");
+	const raw = fs.readFileSync(credsPath, "utf8");
+	const credentials = GeminiOAuthCredentialsSchema.parse(JSON.parse(raw));
+
+	if (
+		credentials.access_token &&
+		(credentials.expiry_date ?? 0) > Date.now() + 60_000
+	) {
+		return credentials.access_token;
+	}
+
+	if (!credentials.refresh_token) return null;
+	return refreshGeminiOAuthAccessToken(credentials.refresh_token);
+}
+
+async function fetchGeminiQuotaBuckets(): Promise<GeminiQuotaBucket[]> {
+	const accessToken = await getGeminiOAuthAccessToken();
+	if (!accessToken) return [];
+
+	const configuredProject =
+		process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
+	const metadata = {
+		ideType: "IDE_UNSPECIFIED",
+		platform: "PLATFORM_UNSPECIFIED",
+		pluginType: "GEMINI",
+		...(configuredProject ? { duetProject: configuredProject } : {}),
+	};
+
+	const loadResponse = CodeAssistLoadResponseSchema.parse(
+		await postCodeAssistJson("loadCodeAssist", accessToken, {
+			cloudaicompanionProject: configuredProject || undefined,
+			metadata,
+		}),
+	);
+
+	const project =
+		loadResponse.cloudaicompanionProject ||
+		loadResponse.response?.cloudaicompanionProject?.id ||
+		configuredProject;
+
+	if (!project) return [];
+
+	const quota = GeminiQuotaResponseSchema.parse(
+		await postCodeAssistJson("retrieveUserQuota", accessToken, { project }),
+	);
+	return quota.buckets ?? [];
+}
+
+function modelBucketMatches(
+	model: Exclude<GeminiCliModel, "auto">,
+	id: string,
+) {
+	if (model === "flash-lite") return id.includes("flash-lite");
+	if (model === "flash")
+		return id.includes("flash") && !id.includes("flash-lite");
+	return id.includes("pro");
+}
+
+function bucketHasQuota(bucket: GeminiQuotaBucket): boolean {
+	if (bucket.remainingAmount !== undefined) {
+		const remaining = Number.parseInt(bucket.remainingAmount, 10);
+		return Number.isFinite(remaining) && remaining > 0;
+	}
+
+	return (bucket.remainingFraction ?? 0) > 0;
+}
+
+export function selectGeminiCliModel(
+	persona: GeminiPersona,
+	buckets: GeminiQuotaBucket[],
+): GeminiCliModel {
+	const models: Exclude<GeminiCliModel, "auto">[] = [
+		"flash",
+		"flash-lite",
+		"pro",
+	];
+	const available = new Map<Exclude<GeminiCliModel, "auto">, boolean>();
+
+	for (const model of models) {
+		const matchingBuckets = buckets.filter(
+			(bucket) => bucket.modelId && modelBucketMatches(model, bucket.modelId),
+		);
+		available.set(
+			model,
+			matchingBuckets.length > 0 && matchingBuckets.some(bucketHasQuota),
+		);
+	}
+
+	const recognizedBuckets = buckets.filter((bucket) =>
+		models.some(
+			(model) => bucket.modelId && modelBucketMatches(model, bucket.modelId),
+		),
+	);
+	const allModelsHaveQuota =
+		models.every((model) => available.get(model)) &&
+		recognizedBuckets.length > 0 &&
+		recognizedBuckets.every(bucketHasQuota);
+	if (allModelsHaveQuota) return "auto";
+
+	const preference: Exclude<GeminiCliModel, "auto">[] =
+		persona === "coder"
+			? ["pro", "flash", "flash-lite"]
+			: ["flash", "flash-lite", "pro"];
+
+	return preference.find((model) => available.get(model)) ?? "auto";
+}
+
+async function resolveGeminiCliModel(
+	persona: GeminiPersona,
+): Promise<GeminiCliModel> {
+	if (!hasGeminiOAuthCredentials()) {
+		logger.info(
+			"Gemini OAuth credentials not found; using Gemini CLI auto model.",
+		);
+		return "auto";
+	}
+
+	try {
+		const buckets = await fetchGeminiQuotaBuckets();
+		if (buckets.length === 0) {
+			logger.info(
+				"Gemini quota buckets unavailable; using Gemini CLI auto model.",
+			);
+			return "auto";
+		}
+
+		const model = selectGeminiCliModel(persona, buckets);
+		if (model === "auto") {
+			logger.info(
+				"All Gemini model quota buckets have remaining quota; using auto model.",
+			);
+		} else {
+			logger.info(`Selected Gemini CLI model '${model}' based on quota.`);
+		}
+		return model;
+	} catch (error) {
+		logger.error(
+			"Failed to inspect Gemini quota; using Gemini CLI auto model.",
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+		);
+		return "auto";
+	}
+}
+
+export function buildGeminiCliArgs(
+	prompt: string,
+	model: GeminiCliModel = "auto",
+): string[] {
 	return [
 		"-y",
 		"@google/gemini-cli",
 		"--debug",
 		"--model",
-		"auto",
+		model,
 		"--prompt",
 		prompt,
 		"--approval-mode",
@@ -648,9 +953,6 @@ ENVIRONMENT:
 - GitHub CLI repository access has been preflight-verified for ${verifiedRepo}.
 - If a gh command fails, report the exact command and stderr instead of inferring an authentication problem.`;
 
-			// Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
-			const args = buildGeminiCliArgs(prompt);
-
 			logger.info("Invoking Gemini CLI...");
 			const childEnv = buildGeminiEnv();
 			childEnv.CONDUCTOR_PERSONA = persona;
@@ -663,6 +965,10 @@ ENVIRONMENT:
 				process.env.GITHUB_WORKSPACE ||
 				path.resolve(process.cwd(), "..");
 			childEnv.CONDUCTOR_TARGET_DIR = targetCwd;
+
+			const geminiModel = await resolveGeminiCliModel(persona);
+			// Invoke the official CLI package in headless mode so Actions does not depend on a preinstalled binary.
+			const args = buildGeminiCliArgs(prompt, geminiModel);
 
 			const result = await runStreamingCommand(
 				"npx",

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildGeminiCliArgs, loadPrompts } from "../src/index";
+import {
+	buildGeminiCliArgs,
+	loadPrompts,
+	selectGeminiCliModel,
+} from "../src/index";
 
 describe("buildGeminiCliArgs", () => {
 	it("runs Gemini CLI in auto model mode with stream-json output", () => {
@@ -19,6 +23,63 @@ describe("buildGeminiCliArgs", () => {
 			"-o",
 			"stream-json",
 		]);
+	});
+
+	it("can pin Gemini CLI to an explicit model", () => {
+		expect(buildGeminiCliArgs("test prompt", "pro")).toContain("pro");
+	});
+});
+
+describe("selectGeminiCliModel", () => {
+	it("allows auto when all model families have quota remaining", () => {
+		expect(
+			selectGeminiCliModel("coder", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
+			]),
+		).toBe("auto");
+	});
+
+	it("prefers flash for conductor when auto is unsafe", () => {
+		expect(
+			selectGeminiCliModel("conductor", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
+			]),
+		).toBe("flash");
+	});
+
+	it("pins a model when any returned model bucket is exhausted", () => {
+		expect(
+			selectGeminiCliModel("coder", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
+				{ modelId: "gemini-3-flash-preview", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
+			]),
+		).toBe("pro");
+	});
+
+	it("prefers pro for coder when auto is unsafe", () => {
+		expect(
+			selectGeminiCliModel("coder", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
+			]),
+		).toBe("pro");
+	});
+
+	it("falls back to an available model when the persona preference is exhausted", () => {
+		expect(
+			selectGeminiCliModel("coder", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.5 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0 },
+			]),
+		).toBe("flash-lite");
 	});
 });
 


### PR DESCRIPTION
## Summary
- query Gemini Code Assist OAuth quota buckets before launching Gemini CLI
- keep `--model auto` only when all returned model buckets have quota remaining
- pin a working model when any bucket is exhausted, preferring `flash` for conductor and `pro` for coder with fallback to another available model
- prefer OAuth credentials over API keys when OAuth credentials are present so quota selection matches the auth path used by Gemini CLI

## Validation
- `npm run test -- tests/prompts.test.ts`
- `npm run build`
- `npm run validate`
- `npm run lint`
- `git diff --check`
