### PR TITLE
[#215] Prefer pro model over auto and flash when quota is available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -406,11 +406,11 @@ export function selectGeminiCliModel(
 			(model) => bucket.modelId && modelBucketMatches(model, bucket.modelId),
 		),
 	);
-	const allModelsHaveQuota =
-		models.every((model) => available.get(model)) &&
-		recognizedBuckets.length > 0 &&
-		recognizedBuckets.every(bucketHasQuota);
-	if (allModelsHaveQuota) return "auto";
+
+	// Prefer pro if it has enough quota (for all tasks/roles)
+	if (available.get("pro")) {
+		return "pro";
+	}
 
 	const preference: Exclude<GeminiCliModel, "auto">[] =
 		persona === "coder"

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -31,22 +31,32 @@ describe("buildGeminiCliArgs", () => {
 });
 
 describe("selectGeminiCliModel", () => {
-	it("allows auto when all model families have quota remaining", () => {
+	it("prefers pro when all model families have quota remaining", () => {
 		expect(
 			selectGeminiCliModel("coder", [
 				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
 				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.1 },
 				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
 			]),
-		).toBe("auto");
+		).toBe("pro");
 	});
 
-	it("prefers flash for conductor when auto is unsafe", () => {
+	it("prefers pro for conductor when available", () => {
 		expect(
 			selectGeminiCliModel("conductor", [
 				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
 				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0 },
 				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
+			]),
+		).toBe("pro");
+	});
+
+	it("prefers flash for conductor when pro is exhausted", () => {
+		expect(
+			selectGeminiCliModel("conductor", [
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.1 },
+				{ modelId: "gemini-2.5-pro", remainingFraction: 0 },
 			]),
 		).toBe("flash");
 	});
@@ -62,11 +72,11 @@ describe("selectGeminiCliModel", () => {
 		).toBe("pro");
 	});
 
-	it("prefers pro for coder when auto is unsafe", () => {
+	it("prefers pro for coder when flash is exhausted", () => {
 		expect(
 			selectGeminiCliModel("coder", [
-				{ modelId: "gemini-2.5-flash", remainingFraction: 0.1 },
-				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-flash", remainingFraction: 0 },
+				{ modelId: "gemini-2.5-flash-lite", remainingFraction: 0.1 },
 				{ modelId: "gemini-2.5-pro", remainingFraction: 0.1 },
 			]),
 		).toBe("pro");


### PR DESCRIPTION
This PR updates the model selection logic to prefer the 'pro' model whenever it has available quota, instead of defaulting to 'auto'.

Changes:
- Updated 'selectGeminiCliModel' in 'src/index.ts' to check for 'pro' quota first.
- Updated 'tests/prompts.test.ts' to verify the new preference logic.

Closes #215